### PR TITLE
Quick: Fix typo in template name in secrets

### DIFF
--- a/frontera-cms/secrets.py
+++ b/frontera-cms/secrets.py
@@ -14,7 +14,7 @@ _LDAP_ENABLED = True
 
 # …
 _CMS_TEMPLATES = (
-    ('fontera-cms/templates/fullwidth.html', 'Fullwidth'),
+    ('frontera-cms/templates/fullwidth.html', 'Fullwidth'),
     ('fullwidth.html', 'DEPRECATED Fullwidth'),
 )
 


### PR DESCRIPTION
# Overview

The default template name has a typo that prevents page creation.

# Changes

Fix typo.