### PR TITLE
Quick: Fix page title inheritance

### DIFF
--- a/example-cms/templates/fullwidth.html
+++ b/example-cms/templates/fullwidth.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load cms_tags staticfiles %}
 
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
 {% block assets_font %}
   {{ block.super }}
 {% endblock assets_font %}

--- a/frontera-cms/templates/fullwidth.html
+++ b/frontera-cms/templates/fullwidth.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load cms_tags staticfiles %}
 
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
 {% block assets_font %}
   {{ block.super }}
 {% endblock assets_font %}

--- a/texascale-org/templates/fullwidth.html
+++ b/texascale-org/templates/fullwidth.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load cms_tags staticfiles %}
 
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
 {% block assets_font %}
   <link rel="stylesheet" href="https://use.typekit.net/xnr7bof.css">
 {% endblock assets_font %}


### PR DESCRIPTION
# Overview

Ensure page title is inherited from Page settings, instead of using sample text.

# Changes

- __Fix__: Add missing `{% block title %}{% page_attribute "page_title" %}{% endblock title %}` to all `fullwidth.html` templates.

# Testing

1. Add unique page title via page settings "Title" field.
2. Ensure step 1 title is used as value for `<title>` tag.
3. Add different unique page title via page settings "Page Title" field.
4. Ensure step 3 title is used as value for `<title>` tag.