### PR TITLE
Quick: Import missing CSS tool

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -1,4 +1,5 @@
 /* TACC TRUMPS: Home (Page) */
+@import url("_imports/tools/x-truncate.css");
 @import url("../../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/x-center.css");
 @import url("../../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/media-queries.css");
 

--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -1,5 +1,5 @@
 /* TACC TRUMPS: Home (Page) */
-@import url("_imports/tools/x-truncate.css");
+@import url("../../../../../../../../taccsite_cms/static/site_cms/_imports/tools/x-truncate.css");
 @import url("../../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/x-center.css");
 @import url("../../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/media-queries.css");
 


### PR DESCRIPTION
# Overview

Import truncate mixin where it is used _i.e. do not rely on it having been included earlier._

# Related

- https://github.com/TACC/Core-CMS/pull/199

# Changes
- __Fix__: Import `x-truncate` mixin from tools in file that relies on it.

# Notes

There will be a build output difference: some code has moved from bottom of stylesheet to top of stylesheet. This movement does not affect the page styles. I tested on https://frontera-portal.tacc.utexas.edu/home-2021-03/.

<details><summary>the code that moves</summary>

`.s-article-preview p:not(:first-child):not(:last-child),.s-home__banner .o-section__banner-overlay p,.x-truncate--many-lines{--lines:2;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;-webkit-line-clamp:var(--lines)}.x-untruncate--many-lines{overflow:visible;-webkit-line-clamp:inherit}.s-article-preview h3,.x-truncate--one-line,[class*=s-article-list--]>h2,[class*=s-article-list--]>p:last-child a{text-overflow:ellipsis;overflow:hidden;white-space:nowrap}.x-untruncate--one-line{overflow:visible;white-space:normal}`

</details>