### PR TITLE
(from Core) Quick: Deprecate site_shared

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -1,7 +1,7 @@
 /* TACC TRUMPS: Home (Page) */
 @import url("../../../../../../../../taccsite_cms/static/site_cms/css/src/_imports/tools/x-truncate.css");
-@import url("../../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/x-center.css");
-@import url("../../../../../../../../taccsite_cms/static/site_shared/css/src/_imports/tools/media-queries.css");
+@import url("../../../../../../../../taccsite_cms/static/site_cms/css/src/_imports/tools/x-center.css");
+@import url("../../../../../../../../taccsite_cms/static/site_cms/css/src/_imports/tools/media-queries.css");
 
 
 


### PR DESCRIPTION
# Overview

See https://github.com/TACC/Core-CMS/pull/218.

# Changes

Update path to new directory for any files previously in Core's `site_shared`.
