### PR TITLE
Hotfix: GH-233: Frontera hero image position

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -73,11 +73,12 @@
 }
 
 /* Image */
-@media (--wide-and-above) {
-  .s-home__banner .o-section__banner-image {
-    /* The offset is to align image at 1200px to position in design */
-    top: calc(50% - 6%); /* overwrite `.o-section__banner-image` */
-  }
+.s-home__banner .o-section__banner-image {
+  /* To overwrite `.o-section__banner-image` */
+  /* To align and size image to match design (as close as possible) */
+  top: calc(50% - 9.5%);
+  left: calc(50% - 13%);
+  width: 124.5vw;
 }
 
 /* List */


### PR DESCRIPTION
# Goal

Set image position and size to match design, and let them be constant.

# Testing

At screen width 1200px, Frontera hero banner image should match design as close as possible.

- Design: [Frontera Prod Home 2021-03](https://frontera-portal.tacc.utexas.edu/home-2021-03/)
- Test Page: [Frontera Redesign](https://xd.adobe.com/view/90e6b252-0293-4243-7748-11d94a0763d0-e6d7/specs/)

At other screen widths, image must always take up full width of page.