### PR TITLE
Hotfix: GH-233: Frontera hero article hover bugs

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -104,8 +104,9 @@
     flex-shrink: 0;
     flex-basis: 100%;
   }
+  /* To reduce space between articles */
   .s-home__banner .o-section__banner-overlay article + article {
-    padding-top: 0;
+    margin-top: calc(-1 * var(--spacing));
   }
 }
 @media (--x-narrow-and-above) {
@@ -114,6 +115,7 @@
     flex-shrink: 1;
     flex-basis: 50%;
   }
+  /* To add line between articles */
   .s-home__banner .o-section__banner-overlay article + article {
     border-left: 1px solid var(--global-color-primary--xx-light);
   }
@@ -137,6 +139,10 @@
   bottom: var(--spacing);
   left: var(--spacing);
   right: var(--spacing);
+  /* Ensure caption shows above image (in Firefox) */
+  /* FAQ: Because `order` is ineffectual due to `position: absolute` */
+  /* SEE: https://css-tricks.com/flexbox-and-absolute-positioning/ */
+  z-index: 1;
 
   padding: 7px var(--spacing);
   /* To overwrite `s-article-preview` */


### PR DESCRIPTION
# Overview

Frontera: Fix bugs with outline on hover over articles in banner.

# Changes

- Ensure equal padding so `outline` behaves (in Firefox & Safari).
- Ensure caption is visible (in Firefox).

# Testing

- Check hover outline at all screen sizes on Firefox and Safari.

# Notes

## Known Issues

1. On wide screen, outline extends too far to the right. This is fixed in a commit in Core.