### PR TITLE
Quick: Remove table border from homepage

### DIFF
--- a/texascale-org/static/texascale-org/css/src/_imports/elements/html-elements.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/elements/html-elements.css
@@ -58,3 +58,16 @@ h6 {
 	margin: 35px 15px 15px 15px;
 	padding: 0px;
 }
+
+
+
+
+
+/* ELEMENTS: Table Content */
+
+table,
+td,
+th {
+  /* A table is only used on the homepage, and a border is not expected */
+  border: none;
+}

--- a/texascale-org/static/texascale-org/css/src/template.article.image-map.css
+++ b/texascale-org/static/texascale-org/css/src/template.article.image-map.css
@@ -5,8 +5,5 @@
 
 /* COMPONENTS */
 
-/* TODO: Make alias for core's `src/` directory */
-/* WARNING: The `c-image-map` is not in Core `main`, yet. */
-/* SEE: https://github.com/TACC/Core-CMS/compare/hotfix/texascale-org/2020-launch */
 @import url("../../../../../../taccsite_cms/static/site_cms/css/src/_imports/components/c-image-map.css");
 @import url("_imports/components/c-image-map.css");

--- a/texascale-org/static/texascale-org/css/src/template.article.image-map.css
+++ b/texascale-org/static/texascale-org/css/src/template.article.image-map.css
@@ -8,5 +8,5 @@
 /* TODO: Make alias for core's `src/` directory */
 /* WARNING: The `c-image-map` is not in Core `main`, yet. */
 /* SEE: https://github.com/TACC/Core-CMS/compare/hotfix/texascale-org/2020-launch */
-/* @import url("../../../../../../taccsite_cms/static/site_cms/css/src/_imports/components/c-image-map.css"); */
+@import url("../../../../../../taccsite_cms/static/site_cms/css/src/_imports/components/c-image-map.css");
 @import url("_imports/components/c-image-map.css");


### PR DESCRIPTION
# Overview

Easily fix two bugs on Texascale.org after testing it against Core using new GitHub repo and the latest code.\*

> \* Dev server was _previously_ using GitLab repo. Prod server is _still_ using GitLab repo (not for long, now).

# Changes

1. __Fix__: Remove borders from Texascale tables
2. __Fix__: Load Core Image Map component for Texascale

# Testing

- Ensure homepage has no borders on section separators.
- Ensure [Frontera Secret Sauce (dev)](https://texascale-dev.tacc.utexas.edu/2020/visualizing-science/frontera-secret-sauce/) looks like [prod](https://texascale.org/2020/visualizing-science/frontera-secret-sauce/).
- Ensure [What's In a Node? (dev)](https://texascale.tacc.utexas.edu/2019/visualizing-science/whats-in-a-node/) looks like [prod](https://texascale.org/2019/visualizing-science/whats-in-a-node/).