### PR TITLE
Quick: A2CPS Template

### DIFF
--- a/a2cps-cms/secrets.py
+++ b/a2cps-cms/secrets.py
@@ -10,7 +10,7 @@
 # DJANGO SETTINGS
 ########################
 
-_LDAP_ENABLED = False
+_LDAP_ENABLED = True
 
 ########################
 # DJANGO CMS SETTINGS
@@ -59,4 +59,4 @@ _LOGO = _A2CPS_LOGO
 # PORTAL
 ########################
 
-_PORTAL = False
+_PORTAL = True

--- a/a2cps-cms/secrets.py
+++ b/a2cps-cms/secrets.py
@@ -18,7 +18,7 @@ _LDAP_ENABLED = True
 
 _CMS_TEMPLATES = (
     ('a2cps-cms/templates/fullwidth.html', 'Fullwidth'),
-    # Support standard template for demo purposes\
+    # Support standard template for demo purposes
     # NOTE: A2CPS will use this instead if it need not load `migration.v1_v2.css
     # ('fullwidth.html', 'Standard Fullwidth'),
 )

--- a/a2cps-cms/templates/fullwidth.html
+++ b/a2cps-cms/templates/fullwidth.html
@@ -14,6 +14,6 @@
 {% block assets_custom %}
   {{ block.super }}
 
-  <!-- TODO: GH-56 a.k.a. TACC/Core-CMS#254: Pending v1 styles -->
+  <!-- TODO: GH-56 a.k.a. TACC/Core-CMS#245: Pending v1 styles -->
   <link rel="stylesheet" href="{% static 'a2cps-cms/css/build/site.css' %}">
 {% endblock assets_custom %}

--- a/a2cps-cms/templates/fullwidth.html
+++ b/a2cps-cms/templates/fullwidth.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% load cms_tags staticfiles %}
+
+{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+
+{% block assets_font %}
+  {{ block.super }}
+{% endblock assets_font %}
+
+{% block content %}
+{% placeholder "content" %}
+{% endblock content %}
+
+{% block assets_custom %}
+  {{ block.super }}
+
+  <!-- TODO: GH-56 a.k.a. TACC/Core-CMS#254: Pending v1 styles -->
+  <link rel="stylesheet" href="{% static 'a2cps-cms/css/build/site.css' %}">
+{% endblock assets_custom %}


### PR DESCRIPTION
# Related

- https://github.com/TACC/Core-CMS/pull/272 is dependent on this PR.

# Overview

- Add missing template.
    - (I forgot to push this commit into https://github.com/TACC/Core-CMS-Resources/pull/57 before merge.)
- Update a couple incorrect secrets values.

# Testing

1. Open https://pprd.a2cps.tacc.utexas.edu/.
2. ✓ Ensure logo is loaded.
3. ✓ Ensure A2CPS "Fullwidth" template is available.
4. Choose A2CPS "Fullwidth" template.
5. ✓ Ensure stylesheet `/static/a2cps-cms/css/build/site.css` is loaded.
    - Stylehsheet is empty. This is accurate.
6. ? Ensure Google Analytics is loaded.