### PR TITLE
GH-81: Fix Favicons Not Loading

### DIFF
--- a/a2cps-cms/templates/fullwidth.html
+++ b/a2cps-cms/templates/fullwidth.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}

--- a/a2cps-cms/templates/standard.html
+++ b/a2cps-cms/templates/standard.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}

--- a/frontera-cms/templates/home.html
+++ b/frontera-cms/templates/home.html
@@ -2,6 +2,8 @@
 {% load cms_tags staticfiles %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   <link rel="stylesheet" href="{% static 'frontera-cms/css/build/site.css' %}">
   <link rel="stylesheet" href="{% static 'frontera-cms/css/build/site.header.css' %}">
 

--- a/protx-cms/templates/fullwidth.html
+++ b/protx-cms/templates/fullwidth.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}

--- a/protx-cms/templates/standard.html
+++ b/protx-cms/templates/standard.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}

--- a/utrc-cms/templates/fullwidth.html
+++ b/utrc-cms/templates/fullwidth.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}

--- a/utrc-cms/templates/standard.html
+++ b/utrc-cms/templates/standard.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}


### PR DESCRIPTION
# Overview & Changes

Add `super` blocks to `assets_custom` blocks that should have it.

# Issues

Closes #81.

# Screenshots

Custom Favicon (UTRC)*
![UTRC](https://user-images.githubusercontent.com/62723358/134394072-33201ae2-5b10-4e62-9c29-f2fbd902dea0.png)

Standard Favicon† (Frontera)
![Frontera](https://user-images.githubusercontent.com/62723358/134394068-14a43b6d-1ae2-41f0-a893-83da01149217.png)

> \* This screenshots shows new UTRC logo, because I was also testing #83.
> † Though this is a standard favicon, the favicon is not in default location browser looks, so it should be tested.

# Testing

0. Ensure favicon is not cached for test. Options:
    - ✅ Visit a project URL with a favicon you have not tried to load. _— confirmed_
    - ❓ Load local site with new URL or port. _— unconfirmed_
    - ⚠️ [Clear your browser's favicon cache](https://www.google.com/search?q=remove+favicon+cache) _— ha ha, good luck_
1. Load CMS using any of these "Project, Template" combinations:
	- A2CPS, Fullwidth
	- A2CPS, Standard
	- Frontera, Home
	- ProTX, Fullwidth
	- ProTX, Standard
	- __UTRC, Fullwidth__*
	- __UTRC, Standard__*

	\* These are the only sites with a custom favicon. Test others for default (blue square with white star).