### PR TITLE
GH-84: Remove UTRC Templates & Migration Styles

### DIFF
--- a/utrc-cms/settings_custom.py
+++ b/utrc-cms/settings_custom.py
@@ -10,8 +10,9 @@
 ########################
 
 CMS_TEMPLATES = (
-    ('utrc-cms/templates/standard.html', 'Standard'),
-    ('utrc-cms/templates/fullwidth.html', 'Full Width'),
+    ('standard.html', 'Standard'),
+    ('fullwidth.html', 'Full Width'),
+
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),

--- a/utrc-cms/static/utrc-cms/css/src/migrate.v1_v2.css
+++ b/utrc-cms/static/utrc-cms/css/src/migrate.v1_v2.css
@@ -1,3 +1,0 @@
-/* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
-
-@import url("../../../../../_shared/static/css/src/migrate.v1_v2.css");

--- a/utrc-cms/static/utrc-cms/css/src/placeholder.css
+++ b/utrc-cms/static/utrc-cms/css/src/placeholder.css
@@ -1,0 +1,3 @@
+/* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
+
+/* At least one stylesheet must exist until CSS build does not assume such */

--- a/utrc-cms/templates/assets_custom.html
+++ b/utrc-cms/templates/assets_custom.html
@@ -1,4 +1,0 @@
-{% load static %}
-
-<!-- To style old CMS content on new CMS -->
-<link rel="stylesheet" href="{% static 'utrc-cms/css/build/migrate.v1_v2.css' %}">

--- a/utrc-cms/templates/fullwidth.html
+++ b/utrc-cms/templates/fullwidth.html
@@ -1,6 +1,0 @@
-{% extends "fullwidth.html" %}
-{% load cms_tags %}
-
-{% block assets_custom %}
-  {% include "./assets_custom.html" %}
-{% endblock assets_custom %}

--- a/utrc-cms/templates/standard.html
+++ b/utrc-cms/templates/standard.html
@@ -1,6 +1,0 @@
-{% extends "standard.html" %}
-{% load cms_tags %}
-
-{% block assets_custom %}
-  {% include "./assets_custom.html" %}
-{% endblock assets_custom %}


### PR DESCRIPTION
# Overview & Changes

- Remove migration styles (no pages needed them).
- Remove templates (only existed to load migration styles).

# Issues

Closes #84.

# Screenshots

<details>
<summary>Standard</summary>

__Content (No Breadcrumbs, No Container)__
![UTRC Standard](https://user-images.githubusercontent.com/62723358/134399468-80b92a1a-080d-4fc6-87e1-ed812a73a3eb.png)

__CSS Files (No Migration Stylesheet)__
![UTRC Standard - CSS Files](https://user-images.githubusercontent.com/62723358/134399945-b9cac99c-c823-4613-86db-16a597c9350c.png)

</details>

<details>
<summary>Full Width</summary>

__Content (No Breadcrumbs, No Container)__
![UTRC Full Width](https://user-images.githubusercontent.com/62723358/134399462-1ff70976-fd2f-4a41-a030-09f02d6c5537.png)

__CSS Files (No Migration Stylesheet)__
![UTRC Full Width - CSS Files](https://user-images.githubusercontent.com/62723358/134399885-3de96cd0-9c17-4136-8ff3-4bd789431024.png)

</details>

# Testing

1. Load site.
2. Have two pages each with one of the default templates:
	- "Standard"
	- "Full Width"
3. Ensure migration stylesheet is not loaded.
4. Ensure templates, "Standard" and "Full Width", have intended content:
    - "Standard" has breadcrumbs and `.container`.
    - "Full Width" has __no__ breadcrumbs and __no__ `.container`.
5. Ensure templates, "Standard" and "Full Width", do not migration stylesheet.