### PR TITLE
Quick: Fix UTRC & Shared Migration CSS

### DIFF
--- a/_shared/static/css/src/_migrations/v1_v2/override-v2.site.css
+++ b/_shared/static/css/src/_migrations/v1_v2/override-v2.site.css
@@ -1,0 +1,9 @@
+/*!
+ * TACC v2 site.css Overrides
+ */
+
+/* ELEMENTS: Content Sectioning: Headings */
+
+h4, h5, h6 {
+	text-transform: unset;
+}

--- a/_shared/static/css/src/migrate.v1_v2.css
+++ b/_shared/static/css/src/migrate.v1_v2.css
@@ -3,3 +3,4 @@
 @import url("_migrations/v1_v2/bootstrap.3.3.7.css");
 @import url("_migrations/v1_v2/angular-material.1.1.8.css");
 @import url("_migrations/v1_v2/main.portal.css");
+@import url("_migrations/v1_v2/override-v2.site.css");

--- a/utrc-cms/static/utrc-cms/css/src/_migrations/v1_v2/bootstrap.3.3.7.css
+++ b/utrc-cms/static/utrc-cms/css/src/_migrations/v1_v2/bootstrap.3.3.7.css
@@ -1,0 +1,17 @@
+/*
+CoreV1 Django CMS Bootstrap 3.3.7
+HOW: Add code that UTRC expects (but need not be added to all migration styles)
+SRC: https://bitbucket.org/taccaci/utrc/src/master/client/css/bootstrap.min.css
+*/
+
+/* … */
+
+.btn-lg,
+.btn-group-lg>.btn {
+ padding:16px 20px;
+ font-size:19px;
+ line-height:1.3333333;
+ border-radius:0
+}
+
+/* … */

--- a/utrc-cms/static/utrc-cms/css/src/migrate.v1_v2.css
+++ b/utrc-cms/static/utrc-cms/css/src/migrate.v1_v2.css
@@ -1,3 +1,4 @@
 /* DO NOT ADD STYLES HERE; ONLY IMPORT OTHER STYLESHEETS */
 
 @import url("../../../../../_shared/static/css/src/migrate.v1_v2.css");
+@import url("./_migrations/v1_v2/bootstrap.3.3.7.css");


### PR DESCRIPTION
# Overview

Minor fixes for UTRC and Shared migration CSS.

# Changes

- Add shared migration overrides to unset h4–h6 capitalization.
- Add UTRC migration additions from Bootstrap 3 for `.btn-lg`.

# Screenshots

__UTRC Home Page Button__
![Button on Home](https://user-images.githubusercontent.com/62723358/134456506-93b0c263-6aa6-43b9-b25c-d0a5d80a6cda.png)

__UTRC Home Page Heading__
![Heading on Home](https://user-images.githubusercontent.com/62723358/134456510-bf9883e2-5fca-4842-b34c-6800a0dece59.png)

__UTRC About Page Headings__
![Heading on About](https://user-images.githubusercontent.com/62723358/134456504-8d0b3764-94f5-4734-8ce6-32221f805e6d.png)

# Testing

__UTRC Home Page Button__
1. Load https://prod.utrc.tacc.utexas.edu/.
2. See button is not as tall as the one on https://utrc.tacc.utexas.edu/.
3. Add styles from `utrc-cms/static/utrc-cms/css/src/_migrations/v1_v2/bootstrap.3.3.7.css`.\*
4. See that button size compared before now matches that of target button.

> \* You can conveniently do this via Developer Tools or Snippet in Footer.

__UTRC Home Page Heading__
1. Load https://prod.utrc.tacc.utexas.edu/about/.
2. See smaller headers are all uppercase, unlike those on https://utrc.tacc.utexas.edu/about/.
3. Add styles from `_shared/static/css/src/_migrations/v1_v2/override-v2.site.css`.\*
4. See that smaller headers are no longer all uppercase.

__UTRC About Page Headings__
1. Load https://prod.utrc.tacc.utexas.edu/.
2. See small header under button is uppercase, unlike that on https://utrc.tacc.utexas.edu/.
3. Add styles from `_shared/static/css/src/_migrations/v1_v2/override-v2.site.css`.\*
4. See that small header is no longer all uppercase.

> \* You can conveniently do this via Developer Tools or Snippet in Footer.