### PR TITLE
Hotfix: Texascale: Post-FP-1194 Fix (Restore Blog)

### DIFF
--- a/texascale-org/settings_custom.py
+++ b/texascale-org/settings_custom.py
@@ -17,10 +17,6 @@ CMS_TEMPLATES = (
 )
 
 ########################
-# BRANDING
-########################
-
-########################
 # LOGOS
 ########################
 
@@ -40,3 +36,78 @@ LOGO =  [
 ########################
 
 INCLUDES_CORE_PORTAL = False
+
+
+
+
+########################
+# FEATURES
+########################
+
+from taccsite_cms.settings import INSTALLED_APPS
+
+FEATURES = {
+    # Blog/News & Social Media Metadata
+    # SEE: https://confluence.tacc.utexas.edu/x/EwDeCg
+    # SEE: https://confluence.tacc.utexas.edu/x/FAA9Cw
+    "blog": True,
+}
+
+
+
+
+
+########################
+# BLOG
+########################
+
+# Install required apps
+INSTALLED_APPS += [
+    # Blog/News
+    # 'filer',              # already added
+    # 'easy_thumbnails',    # already added
+    'parler',
+    'taggit',
+    'taggit_autosuggest',
+    'meta',                 # also supports `djangocms_page_meta`
+    'sortedm2m',
+    'djangocms_blog',
+
+    # Metadata
+    'djangocms_page_meta',
+]
+# CAVEAT: 'taggit_autosuggest' requires the following is added to `urls.py`
+"""
+urlpatterns += [
+    # Support `taggit_autosuggest` (from `djangocms-blog`)
+    url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
+]
+"""
+
+# Metadata: Configure
+META_SITE_PROTOCOL = 'http'
+META_USE_SITES = True
+META_USE_OG_PROPERTIES = True
+META_USE_TWITTER_PROPERTIES = True
+META_USE_GOOGLEPLUS_PROPERTIES = True # django-meta 1.x+
+# META_USE_SCHEMAORG_PROPERTIES=True  # django-meta 2.x+
+
+# Blog/News: Set custom paths for templates
+BLOG_PLUGIN_TEMPLATE_FOLDERS = (
+    ('plugins/default', 'Default template'),    # i.e. `templates/djangocms_blog/plugins/default/`
+    ('plugins/default-clone', 'Clone of default template'),  # i.e. `templates/djangocms_blog/plugins/default-clone/`
+)
+
+# Blog/News: Change default values for the auto-setup of one `BlogConfig`
+# SEE: https://github.com/nephila/djangocms-blog/issues/629
+BLOG_AUTO_SETUP = True
+BLOG_AUTO_HOME_TITLE ='Home'
+BLOG_AUTO_BLOG_TITLE = 'News'
+BLOG_AUTO_APP_TITLE = 'News'
+
+########################
+# CLIENT BUILD SETTINGS
+########################
+
+# TACC/Core-CMS-Resources#75: Load custom urls.py so we can add urlpatterns for taggit_autosuggest
+ROOT_URLCONF = 'taccsite_custom.texascale-org.urls'

--- a/texascale-org/urls.py
+++ b/texascale-org/urls.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from taccsite_cms.urls import *
+
+from django.conf.urls import include, url
+
+urlpatterns += [
+    # Support `taggit_autosuggest` (from `djangocms-blog`)
+    url(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
+]


### PR DESCRIPTION
## Overview

Commit fixes that were tested on Texascale after FP-1194 removed the Blog from Core.

## Testing

Tested on https://texascale-dev.tacc.utexas.edu/ following [(Stand-Alone) CMS Deployment Update](https://confluence.tacc.utexas.edu/display/UP/CMS+Deployment+Update) (and its missing steps).

## Notes

- The diff matches that of `task/GH-73-tacc-blockquote-plugin`...`task/GH-73-tacc-blockquote-plugin--after-FP-1194` ([temporary live diff link](https://github.com/TACC/Core-CMS-Resources/compare/task/GH-73-tacc-blockquote-plugin...task/GH-73-tacc-blockquote-plugin--after-FP-1194)).
- I am merging this already-tested fix so that https://github.com/TACC/Core-CMS-Resources/pull/61 can be merged isolated from this fix.