### PR TITLE
Noop: Texascale: Make 2021 change for robots.txt

### DIFF
--- a/texascale-org/robots.txt
+++ b/texascale-org/robots.txt
@@ -3,5 +3,5 @@ User-agent: *
 # FAQ: This is temporary way to block search engines from early-published pages
 # SEE: https://support.google.com/webmasters/answer/6062608?hl=en&ref_topic=6061961
 # SEE: https://www.matthewedgar.net/noindex-vs-nofollow-vs-disallow/
-# Disallow: /2020
-# Disallow: /2020/
+Disallow: /2021
+Disallow: /2021/


### PR DESCRIPTION
## Overview

Update reference for how to prevent search index of Texascale 2021 pages.

_The pages need to not be indexed **while** they are being developed._

## Changes

- Texascale: Change for 2021 to manually-referenced-only `robots.txt`.

## Testing

- https://texascale-dev.tacc.utexas.edu/robots.txt
- https://texascale.org/robots.txt

## Notes

- This change will not affect anything, because the file is only referenced manually.
- I edit untracked texascale (dev) and texascale (prod) nginx conf to support this.*


> \* Because these servers are not deployed via Camino, yet.