### PR TITLE
Hotfix: Frontera: White Text for Home Banner H3's

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -188,6 +188,7 @@
   margin-bottom: 0;
 
   font-size: 1.6rem;
+  /* FP-1318: Migrate this to Section plugin which can handle all headings */
   color: var(--global-color-primary--xx-light);
 }
 /* Caption: Type */


### PR DESCRIPTION
## Required By

- https://github.com/TACC/Core-CMS/pull/384

## Overview

Define color for expected headings i.e. override inherited colors from base element styles.

## Issues

After cloning prod to pre-prod, one bug was found that must be fixed before deploy.

- [FP-1273: [...] Prep for Deploy](https://jira.tacc.utexas.edu/browse/FP-1273)
- [FP-1252: Clone Frontera CMS Prod to Pre-Prod](https://jira.tacc.utexas.edu/browse/FP-1252)

## Screenshots

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/62723358/138929990-4f09bae4-f94c-4443-8500-dde7cb005643.png) | ![After](https://user-images.githubusercontent.com/62723358/138929976-6639508d-3d0f-4d61-9f96-1e38d53643cf.png) |

## Testing

Confirm that change makes the home banner heading text color in [pre-prod](https://pprd.frontera-portal.tacc.utexas.edu/) match [production](https://frontera-portal.tacc.utexas.edu/).

__Quick Way__: Reproduce adding style on [Frontera Pre-Prod](https://pprd.frontera-portal.tacc.utexas.edu/) (i.e. recreate "After" screenshot state).

__Long Way__: [(wiki) Test CMS Changes](https://github.com/TACC/Core-CMS/wiki/Test-CMS-Changes) with this branch.