### PR TITLE
Hotfix: BM-5/BM-19: Fix link to SGCI (was NSF)

### DIFF
--- a/brainmap-cms/settings_custom.py
+++ b/brainmap-cms/settings_custom.py
@@ -27,7 +27,7 @@ _SGCI_BRANDING = [
     "sgci",
     "brainmap-cms/img/org_logos/sgci-logo.png",
     "branding-logo--tall",
-    "https://www.nsf.gov/",
+    "https://sciencegateways.org/",
     "_blank",
     "SGCI Logo",
     "anonymous",


### PR DESCRIPTION
## Overview

Fix SGCI image to link to SGCI site, not NSF.

## Required By

- https://github.com/TACC/Core-CMS/pull/398