### PR TITLE
Hotfix/FP-1330: Frontera: Fix Favicon Load on Standard Template

### DIFF
--- a/frontera-cms/templates/standard.html
+++ b/frontera-cms/templates/standard.html
@@ -2,5 +2,7 @@
 {% load cms_tags %}
 
 {% block assets_custom %}
+  {{ block.super }}
+
   {% include "./assets_custom.html" %}
 {% endblock assets_custom %}


### PR DESCRIPTION
## Required By

- https://github.com/TACC/Core-CMS/pull/401

## Overview

Ensure favicon loads on Frontera standard template.

## Testing

1. Load https://pprd.frontera-portal.tacc.utexas.edu/system. [^0]
1. Verify favicon is a black field with a gray longhorn head.
    - **not** a white star on blue gradient
    - **not** a blue favicon with the word TACC
2. Verify favicon URL in markup is `/static/frontera-cms/img/org_logos/favicon.ico`.

[^0]: Deployed via https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/849/ which loads image from CMS branch `main--v3-3-0-with-hotfixes`.

## Issues

[FP-1330](https://jira.tacc.utexas.edu/browse/FP-1330)