### PR TITLE
Hotfix/FP-1338: Offset Content to be Full Width on Narrow Window

### DIFF
--- a/texascale-org/static/texascale-org/css/src/_imports/components/deprecated/c-offset-content.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/components/deprecated/c-offset-content.css
@@ -14,8 +14,6 @@ Styleguide Components.Texascale.Deprecated.OffsetContent
 [class*="c-offset-content--"] {
   --offset-distance: 8.5vw; /* NOTE: Value is from Texascale.org 2020 */
 	--buffer: 30px; /* double Bootstrap `.col` padding */
-
-  max-width: 50%;
 }
 
 @media only screen and (--medium-and-above) {
@@ -32,7 +30,10 @@ Styleguide Components.Texascale.Deprecated.OffsetContent
 	.c-offset-content--left + .c-offset-content--left { clear: left; }
 }
 @media only screen and (--medium-and-above) and (--max-wide-and-below) {
-    /* Apply negative margin only when using offset value */
+  [class*="c-offset-content--"] {
+    max-width: 50%;
+  }
+  /* Apply negative margin only when using offset value */
 	.c-offset-content--right {
 		margin-right: calc( var(--offset-distance) * -1);
 	}


### PR DESCRIPTION
## Required By

- https://github.com/TACC/Core-CMS/pull/406

## Overview

Ensure `c-offset-content` elements are full width on narrow windows.

## Issues

[FP-1338](https://jira.tacc.utexas.edu/browse/FP-1338)

## Screenshots

| Narrow Window | Wide Window |
| - | - |
| ![Narrow Window](https://user-images.githubusercontent.com/62723358/141350606-7d0b190d-1f2a-452a-a5f1-d3d2055b2ebc.png) | ![Wide Window](https://user-images.githubusercontent.com/62723358/141350603-b445e6f3-031e-490c-b881-28c51a568307.png) |

## Testing

1. Open https://texascale-dev.tacc.utexas.edu/2020/feature-stories/twisted-physics/.
2. On wide window, find offset content (content offset from flow of article text).
3. Ensure offset content:
    - _does **not**_ span 100% of container
    - is offset
    - text wraps around one end of it
4. On narrow window, find the content that was offset (it should now be in flow with article text).
5. Ensure content that was offset
    - _does_ span 100% of container
    - **not** offset
    - text _does **not**_ wraps around one end of it

## Notes

The `c-offset-content` is deprecated but still used on Texascale.