### PR TITLE
Bug/FP-1422: Remove white border under header.

### DIFF
--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -78,6 +78,16 @@
 
 
 
+/* Banner: Image */
+
+/* Temporary fix to get rid of white border on top of banner */
+.o-section--banner .o-section__banner-image {
+  top: 0%;
+  transform: translate(-50%, 0%);
+}
+
+
+
 
 
 /* Introduction */


### PR DESCRIPTION
## Overview: ##
Remove white border under header in utrc.

## Related Jira tickets: ##

* [FP-1422](https://jira.tacc.utexas.edu/browse/FP-1422)
 
## Summary of Changes: ##
Overrided the `.o-section__banner-image` style for utrc.

## Testing Steps: ##
1. Ensure that the white border doesn't show with the utrc layout locally.
<details>
<summary>Local layout I tested with</summary>

![Screenshot from 2022-01-12 10-51-09](https://user-images.githubusercontent.com/9425579/149185317-7eadeabb-03bc-4d3d-a416-c45d86b20355.png)

</details>  

2. Ensure that this change doesn't affect other UI elements.

## UI Photos:
![Screenshot from 2022-01-12 10-33-17](https://user-images.githubusercontent.com/9425579/149185693-34e52da2-c891-40f1-a13b-1dae17118dc3.png)

## Notes: ##
<details>
<summary>What was the core issue?</summary>

There seems to be some monkey business between the:
 - `rem` height of `.s-home__banner` [overrided by utrc](https://github.com/TACC/Core-CMS-Resources/blob/1987e4eb2c5f31140b78d806ee3698215aec4047/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css#L43) in `/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css` and the `transform` and
 - `top` of the `.o-section__banner-image` in `taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css` ([here](https://github.com/TACC/Core-CMS/blob/d7732895252c57e78b77cbfddefc95b56566aa2b/taccsite_cms/static/site_cms/css/src/_imports/objects/o-section.css#L211)).

I'm not sure how this will affect other ui elements (if this change goes into `o-section` for [FP-1318](https://jira.tacc.utexas.edu/browse/FP-1318)), but setting `top: 0%` and `transform: translate(-50%, 0%)` seems to act the same without interfering with the height changes. 

It also seems like frontera also [overrides](https://github.com/TACC/Core-CMS-Resources/blob/90d3667c5e6e9dee8649ef55a4ccdc15f4d4ab89/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css#L100) the `top` value to make it work.

Manually changing the height of the banner image seems to re-introduced the issue when zooming in/out.

</details>
