### PR TITLE
FP-1318: Revisit Section Pattern (Frontera) (UTRC)

### DIFF
--- a/frontera-cms/templates/home.html
+++ b/frontera-cms/templates/home.html
@@ -13,14 +13,6 @@
   html { font-size: 62.5%; /* 1rem = 10px */ }
   </style>
 
-  {# TODO: FP-1318: Solve section overflow in `o-section` code #}
-  <style>
-  /* To hide `.o-section--style-…` and `.o-section__banner-image` overflow */
-  /* FAQ: Isolate from Core and Frontera to avoid unexpected side-effects */
-  main,
-  /* HACK: Using ID until upstream updates markup via `quick/create-and-document-element-stylesheets` */
-  #content-wrap { overflow: hidden; }
-  </style>
   <link rel="stylesheet" href="{% static 'frontera-cms/css/build/template.home.css' %}">
 {% endblock assets_custom %}
 

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -13,9 +13,9 @@
 /* To avoid banner overlay being off-screen */
 @media (--medium-and-above) and (--x-wide-and-below) {
   /* FAQ: Extra specificty to overwrite Core `site.css` */
-  .s-home__banner.o-section.container,
-  .s-home__content.o-section.container {
-    --horz-space: 116px;
+  .s-home__banner.o-section,
+  .s-home__content.o-section {
+    margin-block: 116px;
   }
 }
 

--- a/utrc-cms/templates/home.html
+++ b/utrc-cms/templates/home.html
@@ -4,14 +4,6 @@
 {% block assets_custom %}
   {{ block.super }}
 
-  {# TODO: FP-1318: Solve section overflow in `o-section` code #}
-  <style>
-  /* To hide `.o-section--style-…` and `.o-section__banner-image` overflow */
-  /* FAQ: Isolate from Core and Frontera to avoid unexpected side-effects */
-  main,
-  /* HACK: Using ID until upstream updates markup via `quick/create-and-document-element-stylesheets` */
-  #content-wrap { overflow: hidden; }
-  </style>
   <link rel="stylesheet" href="{% static 'utrc-cms/css/build/template.home.css' %}">
 {% endblock assets_custom %}
 


### PR DESCRIPTION
### Required By

- https://github.com/TACC/Core-CMS/pull/433

### Overview

- Solve section overflow in `o-section` code (not in templates).
- Use simpler CSS (for code related to code in [#433](https://github.com/TACC/Core-CMS/pull/433) that also got simplified).