### PR TITLE
Quick: (UTRC-357/FP-1268) Remove old templates

### DIFF
--- a/utrc-cms/settings_custom.py
+++ b/utrc-cms/settings_custom.py
@@ -11,10 +11,6 @@ CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
 
-    # DEPRECATED! Remove once unused on prod environment
-    ('utrc-cms/templates/standard.html', 'DEPRECATED Standard'),
-    ('utrc-cms/templates/fullwidth.html', 'DEPRECATED Full Width'),
-
     ('utrc-cms/templates/home.html', 'Home'),
 
     ('guide.html', 'Guide'),

--- a/utrc-cms/templates/fullwidth.html
+++ b/utrc-cms/templates/fullwidth.html
@@ -1,2 +1,0 @@
-{% extends "fullwidth.html" %}
-{# DEPRECATED! Remove once unused on prod environment #}

--- a/utrc-cms/templates/standard.html
+++ b/utrc-cms/templates/standard.html
@@ -1,2 +1,0 @@
-{% extends "standard.html" %}
-{# DEPRECATED! Remove once unused on prod environment #}


### PR DESCRIPTION
## Overview

Remove deprecated UTRC templates.

## Testing

1. Confirm these pages can load:
    - [(pre-prod) `/publications/`](https://utrc.tacc.utexas.edu/publications/)
    - [(pre-prod) `/about/`](https://utrc.tacc.utexas.edu/about/)
3. Confirm styles match those on prod:
    - [(prod) `/publications/`](https://utrc.tacc.utexas.edu/publications/)
    - [(prod) `/about/`](https://utrc.tacc.utexas.edu/about/)

## Notes

UTRC pprd and prod pages have been updated to use new templates.