### PR TITLE
FP-1525: UTRC: Fix Homepage Whitespace

### DIFF
--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -12,13 +12,10 @@
 
 /* To avoid banner overlay being off-screen */
 @media (--medium-and-above) and (--x-wide-and-below) {
-  /* FAQ: Extra specificty to overwrite Core `site.css` */
-  .s-home__banner.o-section,
-  .s-home__content.o-section {
+  .o-section {
     margin-inline: 116px;
   }
-  .s-home__banner.o-section.container,
-  .s-home__content.o-section.container {
+  .o-section.container {
     width: auto;
   }
 }

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -17,6 +17,10 @@
   .s-home__content.o-section {
     margin-inline: 116px;
   }
+  .s-home__banner.o-section.container,
+  .s-home__content.o-section.container {
+    width: auto;
+  }
 }
 
 

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -15,7 +15,7 @@
   /* FAQ: Extra specificty to overwrite Core `site.css` */
   .s-home__banner.o-section,
   .s-home__content.o-section {
-    margin-block: 116px;
+    margin-inline: 116px;
   }
 }
 


### PR DESCRIPTION
## Overview

Fix a typo and neglected style that led to vertical space instead of horizontal space.

Also, reduce over-specificity.

## Issues

- __[FP-1525](https://jira.tacc.utexas.edu/browse/FP-1525)__
- Review Ticket: [FP-1529](https://jira.tacc.utexas.edu/browse/FP-1529)

## Screenshots

|  | 576px | 768px | 992px | 1200px | 1400px | 1680px |
| - | - | - | - | - | - | - |
| Broken | — | — | ![UTRC Home Broken FP-1525 992px](https://user-images.githubusercontent.com/62723358/155621369-73d31814-f61d-4b78-8693-175b8bbc016a.jpeg) | ![UTRC Home Broken FP-1525 1200px](https://user-images.githubusercontent.com/62723358/155621373-0fa86324-4ffa-420a-bead-db8a9bed406a.jpeg) | — | — |
| Fixed | ![UTRC Home Stage 576px](https://user-images.githubusercontent.com/62723358/155621096-da3e9d86-5a19-4c5c-aa99-35985d9f2109.jpeg) | ![UTRC Home Stage 768px](https://user-images.githubusercontent.com/62723358/155621102-80b09eec-9639-415d-b03d-0a52efd0965e.jpeg) | ![UTRC Home Stage 992px](https://user-images.githubusercontent.com/62723358/155621104-524208d3-cdf8-4102-8d11-4d1a128b7d18.jpeg) | ![UTRC Home Stage 1200px](https://user-images.githubusercontent.com/62723358/155621106-832823a4-803f-45b7-a814-4f367ae42626.jpeg) | ![UTRC Home Stage 1400px](https://user-images.githubusercontent.com/62723358/155621107-ed6c13f9-7447-43a3-a500-42454f630606.jpeg) | ![UTRC Home Stage 1680px](https://user-images.githubusercontent.com/62723358/155621110-741e6515-3add-48ec-83dc-d9f6d7eccfad.jpeg) |
| Prod | ![UTRC Home Prod 576px](https://user-images.githubusercontent.com/62723358/155582490-c14e91b7-ab8c-4b5e-a29a-fea297b16767.jpeg) | ![UTRC Home Prod 768px](https://user-images.githubusercontent.com/62723358/155582492-5d58265d-6888-4e2b-8b12-f00dd1a87d4a.jpeg) | ![UTRC Home Prod 992px](https://user-images.githubusercontent.com/62723358/155582493-be9ab8da-b34a-470e-8b85-9559acf2e936.jpeg) | ![UTRC Home Prod 1200px](https://user-images.githubusercontent.com/62723358/155582495-b8d7276d-49c2-4bb2-a669-6dfc7d9f31f6.jpeg) | ![UTRC Home Prod 1400px](https://user-images.githubusercontent.com/62723358/155582496-23f1bb2f-6d39-4384-9c69-f9bd65511c1f.jpeg) | ![UTRC Home Prod 1680px](https://user-images.githubusercontent.com/62723358/155582498-3447f81b-2f8d-49ab-b39e-d2f8a7f7541a.jpeg) |

## Testing

Confirm [UTRC (pre-prod)](https://pprd.utrc.tacc.utexas.edu/) and [UTRC (prod)](https://utrc.tacc.utexas.edu/) styles match (forgive `15px` of horz. space[^1]) at [screen widths](https://confluence.tacc.utexas.edu/x/b4AZCg) between "XX Wide" (`1680px`) and "Narrow" (`576px`).

<details>
<summary>Deploy Tracking</summary>

- Build: https://jenkins01.tacc.utexas.edu/job/Core_CMS_Build/391/
- Deploy: https://jenkins01.tacc.utexas.edu/job/Core_Portal_Deploy/1107/

</details>


[^1]: There is `15px` more horizontal space on sections, because I let Containers' spacing take effect (since FP-1318).[^2]
[^2]: I previously fought Bootstrap Containers (Bootstrap anything, really), but CMS Editors will use them, and I don't have time to replace all of https://github.com/django-cms/djangocms-bootstrap4, so I now build **with** the Bootstrap instead of **against** it.