### PR TITLE
Quick: Example: Comment Out `INCLUDES_CORE_PORTAL = False`

### DIFF
--- a/example-cms/settings_custom.py
+++ b/example-cms/settings_custom.py
@@ -65,4 +65,5 @@ BRANDING = [ _NSF_BRANDING, _TACC_BRANDING, _UTEXAS_BRANDING ]
 # PORTAL
 ########################
 
-INCLUDES_CORE_PORTAL = False
+# Should a user be able to see link to Portal? (default value: True)
+# INCLUDES_CORE_PORTAL = False # True to show login link, False to hide login link


### PR DESCRIPTION
## Overview

There is a default setup or new projects that should not be the default. Having a Portal is the more common use case.

## Changes

In `example-cms` project:
- Disable `INCLUDES_CORE_PORTAL` setting.
- Comment how to use, default value, and value meanings.