### PR TITLE
Quick: UTRC: Fix Homepage Focus List Text Size

### DIFF
--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -172,7 +172,7 @@
 /* Content: Focus List */
 
 .s-home__content .s-focus-list {
-  font--size: var(--global-font-size--large);
+  font-size: var(--global-font-size--large);
 }
 
 


### PR DESCRIPTION
## Overview

I noticed text-size CSS had typo, so it wasn't applied. I fix it.

## Changes

- UTRC homepage focus list text size will match the text size of h2 above it.

## Notes

The focus list is intend to look like a continuation of the h2, albeit still as content, not as the title proper. 