### PR TITLE
GH-149: Updates for TACC/Core-CMS#149 (base.html polish)

### DIFF
--- a/texascale-org/static/texascale-org/css/src/_imports/elements/html-elements.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/elements/html-elements.css
@@ -1,8 +1,6 @@
 /* ELEMENTS: Content Sectioning */
 
-main,
-/* NOTE: Using ID until it is replaced with `main` */
-#content-wrap {
+main {
   padding-bottom: var(--global-space-beneath-main-content);
 }
 
@@ -16,7 +14,7 @@ main,
 - `h6` = byline/category header
 */
 
-/* NOTE: If scope classes are implemented, then these would be nested under a `.s-cms-content` */
+/* NOTE: If scope classes are implemented, then these would be nested under a `.s-cms-text` */
 
 h1, h3 {
 	font-family: benton-sans, sans-serif;

--- a/texascale-org/static/texascale-org/css/src/page.dispatches-frontera.css
+++ b/texascale-org/static/texascale-org/css/src/page.dispatches-frontera.css
@@ -4,9 +4,7 @@
 /* ELEMENTS: (Content) Sectioning Elements */
 
 /* Overwrite `_imports/elements/sectioning.css` */
-main,
-/* NOTE: Using ID until it is replaced with `main` */
-#content-wrap {
+main {
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
## Overview

Remove legacy selectors.

## Related

- https://github.com/TACC/Core-CMS-Resources/issues/25
- requires https://github.com/TACC/Core-CMS/pull/151

## Changes

- Delete legacy part of Texascale CSS selectors.
- (Unrelated) Rename a suggested classname.