### PR TITLE
wip-feat(fp-1487): pythonic app template load

### DIFF
--- a/_readme-cms/_templates/README.md
+++ b/_readme-cms/_templates/README.md
@@ -1,32 +1,19 @@
 # TACC CMS Project - Example - Templates
 
-Templates specific to this project __must__ be in this directory.
-Otherwise, they will be unavailable to [Core CMS] loading this project.
+You may overwrite Core CMS templates and 3rd-party apps/plugin templates.
 
-The directory structure here __should__ mirror [Core CMS]:
-  [`/taccsite_cms/templates`][core-tpl-dir]
+## Page Templates
 
-This consistency lets us override templates in Django fashion.
+To make new templates available as page templates for CMS editors, replace or add to `CMS_TEMPLATES` setting.
 
-[Core CMS]: https://github.com/TACC/Core-CMS
-[core-tpl-dir]: https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/static/site_cms
+## Overwrite Core
 
-## How to Write Template Path
-
-Where `name-of-project` is a CMS projects with custom templates:
-
-- `/name-of-project/templates/___.html`
-
-### How to Overwrite Core Templates
-
-1. Create a template of the same name here.
-2. Reference the template (where needed) with the correct path.
-
-⚠️ A project __must not__ overwrite the Core CMS `base.html`.
+1. Create a template of the same name as the [Core CMS template][core-tpl-dir] to overwrite.
+2. Replace or extend the content of the overwritten template.
 
 ## Overwrite Apps or Plugins
 
-You may overwrite apps [like Core][core-overwrite-doc].
-But you msut do so relative to this directory.
+Follow [Core CMS instructions][core-tpl-doc], but within _this_ directory instead.
 
-[core-overwrite-doc]: https://github.com/TACC/Core-CMS/tree/main/taccsite_cms/templates/README.md#overwrite-apps-or-plugins
+[core-tpl-dir]: https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/static/site_cms
+[core-tpl-doc]: https://github.com/TACC/Core-CMS/tree/main/taccsite_cms/templates

--- a/frontera-cms/settings_custom.py
+++ b/frontera-cms/settings_custom.py
@@ -10,9 +10,10 @@
 ########################
 
 CMS_TEMPLATES = (
-    ('frontera-cms/templates/standard.html', 'Standard'),
-    ('frontera-cms/templates/fullwidth.html', 'Full Width'),
-    ('frontera-cms/templates/home.html', 'Homepage'),
+    ('standard.html', 'Standard'),
+    ('fullwidth.html', 'Full Width'),
+
+    ('home.html', 'Homepage'),
 
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
@@ -20,6 +21,14 @@ CMS_TEMPLATES = (
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
+
+# FP-1645: Remove CMS_TEMPLATES_DEPRECATED
+CMS_TEMPLATES_DEPRECATED = (
+    ('frontera-cms/templates/standard.html', 'DEPRECATED Standard'),
+    ('frontera-cms/templates/fullwidth.html', 'DEPRECATED Full Width'),
+    ('frontera-cms/templates/home.html', 'DEPRECATED Homepage'),
+)
+CMS_TEMPLATES = CMS_TEMPLATES + CMS_TEMPLATES_DEPRECATED
 
 ########################
 # TACC: BRANDING

--- a/neuronex-cms/settings_custom.py
+++ b/neuronex-cms/settings_custom.py
@@ -10,14 +10,22 @@
 ########################
 
 CMS_TEMPLATES = (
-    ('neuronex-cms/templates/fullwidth.html', 'Fullwidth'),
+    ('fullwidth.html', 'Fullwidth'),
+
     ('home_portal.html', 'Standard Portal Homepage'),
+
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
+
+# FP-1645: Remove CMS_TEMPLATES_DEPRECATED
+CMS_TEMPLATES_DEPRECATED = (
+    ('neuronex-cms/templates/fullwidth.html', 'DEPRECATED Fullwidth'),
+)
+CMS_TEMPLATES = CMS_TEMPLATES + CMS_TEMPLATES_DEPRECATED
 
 ########################
 # TACC: BRANDING

--- a/neuronex-cms/templates/fullwidth.html
+++ b/neuronex-cms/templates/fullwidth.html
@@ -1,15 +1,5 @@
-{% extends "base.html" %}
+{% extends "fullwidth.html" %}
 {% load cms_tags staticfiles %}
-
-{% block title %}{% page_attribute "page_title" %}{% endblock title %}
-
-{% block assets_font %}
-  {{ block.super }}
-{% endblock assets_font %}
-
-{% block content %}
-{% placeholder "content" %}
-{% endblock content %}
 
 {% block assets_custom %}
   {{ block.super }}

--- a/protx-cms/settings_custom.py
+++ b/protx-cms/settings_custom.py
@@ -14,11 +14,17 @@ CMS_TEMPLATES = (
     ('fullwidth.html', 'Full Width'),
 
     ('guide.html', 'Guide'),
-    ('protx-cms/templates/getting_started.html', 'Guide: Getting Started'),
+    ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
+
+# FP-1645: Remove CMS_TEMPLATES_DEPRECATED
+CMS_TEMPLATES_DEPRECATED = (
+    ('protx-cms/templates/getting_started.html', 'DEPRECATED Guide: Getting Started'),
+)
+CMS_TEMPLATES = CMS_TEMPLATES + CMS_TEMPLATES_DEPRECATED
 
 ########################
 # TACC: (DEPRECATED)

--- a/texascale-org/settings_custom.py
+++ b/texascale-org/settings_custom.py
@@ -7,14 +7,26 @@
 ########################
 
 CMS_TEMPLATES = (
-    ('texascale-org/templates/fullwidth.html', 'Fullwidth'),
-    ('texascale-org/templates/category.html', 'Category'),
-    ('texascale-org/templates/article.html', 'Article'),
-    ('texascale-org/templates/article.freeform.html', 'Article (Free-Form)'),
-    ('texascale-org/templates/article.sidebar-right.html', 'Article (Right Sidebar)'),
-    ('texascale-org/templates/article.visual.html', 'Article (Full-Size Visual)'),
-    ('texascale-org/templates/article.image-map.html', 'Article (Image Map)'),
+    ('fullwidth.html', 'Fullwidth'),
+    ('category.html', 'Category'),
+    ('article.html', 'Article'),
+    ('article.freeform.html', 'Article (Free-Form)'),
+    ('article.sidebar-right.html', 'Article (Right Sidebar)'),
+    ('article.visual.html', 'Article (Full-Size Visual)'),
+    ('article.image-map.html', 'Article (Image Map)'),
 )
+
+# FP-1645: Remove CMS_TEMPLATES_DEPRECATED
+CMS_TEMPLATES_DEPRECATED = (
+    ('texascale-org/templates/fullwidth.html', 'DEPRECATED Fullwidth'),
+    ('texascale-org/templates/category.html', 'DEPRECATED Category'),
+    ('texascale-org/templates/article.html', 'DEPRECATED Article'),
+    ('texascale-org/templates/article.freeform.html', 'DEPRECATED Article (Free-Form)'),
+    ('texascale-org/templates/article.sidebar-right.html', 'DEPRECATED Article (Right Sidebar)'),
+    ('texascale-org/templates/article.visual.html', 'DEPRECATED Article (Full-Size Visual)'),
+    ('texascale-org/templates/article.image-map.html', 'DEPRECATED Article (Image Map)'),
+)
+CMS_TEMPLATES = CMS_TEMPLATES + CMS_TEMPLATES_DEPRECATED
 
 ########################
 # TACC: LOGOS

--- a/utrc-cms/settings_custom.py
+++ b/utrc-cms/settings_custom.py
@@ -11,7 +11,7 @@ CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
 
-    ('utrc-cms/templates/home.html', 'Home'),
+    ('home.html', 'Home'),
 
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
@@ -19,6 +19,12 @@ CMS_TEMPLATES = (
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
+
+# FP-1645: Remove CMS_TEMPLATES_DEPRECATED
+CMS_TEMPLATES_DEPRECATED = (
+    ('utrc-cms/templates/home.html', 'DEPRECATED Home'),
+)
+CMS_TEMPLATES = CMS_TEMPLATES + CMS_TEMPLATES_DEPRECATED
 
 ########################
 # TACC: LOGOS


### PR DESCRIPTION
## Overview

Make template overwrites not require adding new entry to `CMS_TEMPLATES`.

## Related

- [FP-1487](https://jira.tacc.utexas.edu/browse/FP-1487)
- coupled with https://github.com/TACC/Core-CMS/pull/487

## Changes

- deprecate project-specific template paths with short ones
- update documentation

## Testing

1. …

## Screenshots

…

## Notes

This didn't work. I thought it was easy. Guess not. This PR is for reference.
