### PR TITLE
Task/fp 1439 yearly site theme for texascale

### DIFF
--- a/texascale-org/templates/base.html
+++ b/texascale-org/templates/base.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load staticfiles get_url_match %}
+
+{% block assets_custom %}
+  {{ block.super }}
+
+  {% with path|get_url_match:"/20\d\d/" as year_slug %}
+    {% if year_slug %}
+      {% with path = "texascale-org/css/build/site."|add:year_slug:add|".css" %}
+  <link rel="stylesheet" href="{% static path %}">
+      {% endwith %}
+    {% endif %}
+  {% endwith %}
+{% endblock assets_custom %}

--- a/texascale-org/templates/djangocms_blog/base.html
+++ b/texascale-org/templates/djangocms_blog/base.html
@@ -1,0 +1,15 @@
+{# https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/templates/djangocms_blog/base.html #}
+{% extends "djangocms_blog/base.html" %}
+{% load static get_url_match %}
+
+{% block content_assets %}
+  {{ block.super }}
+
+  {% with path|get_url_match:"/20\d\d/" as year_slug %}
+    {% if year_slug %}
+      {% with path = "texascale-org/css/build/app.blog."|add:year_slug:add|".css" %}
+  <link rel="stylesheet" href="{% static path %}">
+      {% endwith %}
+    {% endif %}
+  {% endwith %}
+{% endblock content_assets %}

--- a/texascale-org/templates/fullwidth.html
+++ b/texascale-org/templates/fullwidth.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "./base.html" %}
 {% load cms_tags staticfiles %}
 
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}


### PR DESCRIPTION
## Overview

For Texascale, support annual `site.css` and `app.blog.css` (e.g. `site.2022.css`, `app.blog.2022.css`).

## Related

- [FP-1439](https://jira.tacc.utexas.edu/browse/FP-1439)
- required by https://github.com/TACC/Core-CMS/pull/490

## Changes

- feat(fp-1439): extend base.html to load annual CSS - 048eb81
- feat(fp-1439): extend blog to load annual CSS - 08727a1

## Testing & Screenshots

See https://github.com/TACC/Core-CMS/pull/490.
