### PR TITLE
feat(tup): no LDAP (Portal will manage users)

### DIFF
--- a/tup-cms/settings_custom.py
+++ b/tup-cms/settings_custom.py
@@ -3,6 +3,12 @@
 # *.TUP.TACC.UTEXAS.EDU
 
 ########################
+# DJANGO SETTINGS
+########################
+
+LDAP_ENABLED = False
+
+########################
 # DJANGO CMS SETTINGS
 ########################
 


### PR DESCRIPTION
## Overview

Do not enable LDAP for TUP CMS.

_Because J.Y. said not to… I believe because Portal will mediate LDAP auth via single-sign-on, and new TUP CMS does not need all staff to be able to be users._

## Related

- https://github.com/TACC/Core-CMS/pull/499

## Testing / Screenshots

(skipped)

## Changes

- set LDAP setting to false