### PR TITLE
feat(tup-230): frontera primary button styles (i.e. add color vars)

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/settings/color.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/settings/color.css
@@ -1,6 +1,13 @@
 /* SETTINGS: Color */
 
 :root {
-    /* Distinct Hues */
-    --global-color-accent--normal: #877453;
+  /* Accent Hues */
+  --global-color-accent--x-light: #F2DFBD; /* originally #e3d7fd */
+  --global-color-accent--light: #BDA374;   /* originally #a387ed */
+  --global-color-accent--normal: #877453;  /* originally #784fe8 */
+  --global-color-accent--dark: #64563E;    /* originally #6039cc */
+  --global-color-accent--x-dark: #403014;  /* originally #3d189b */
+
+  --global-color-accent--alt: #E0D8C9; /* #d2cce7 */
+  --global-color-accent--weak: #9D702140; /* #6039cc40 */
 }


### PR DESCRIPTION
## Overview

Add Frontera-specific values for new accent color variables.

## Related

- https://github.com/TACC/Core-CMS/pull/500
- mimics https://github.com/TACC/Core-CMS-Resources/pull/144 but on `release/v3.6.0` branch instead of main