### PR TITLE
After/tup 271 fp 1665 submod changes (a2cps migration css tweak)

### DIFF
--- a/a2cps-cms/static/a2cps-cms/css/src/_migrations/v1_v2/a2cps.css
+++ b/a2cps-cms/static/a2cps-cms/css/src/_migrations/v1_v2/a2cps.css
@@ -37,17 +37,6 @@ td {
 
 
 
-/* COMPONENTS: TACC */
-
-/* Footer */
-
-.c-footer {
-  /* To mimic 2020 site `#footer` styles */
-  margin: 0;
-}
-
-
-
 /* COMPONENTS: Bootstrap */
 
 /* Cards */


### PR DESCRIPTION
## Overview

Do not unset footer margin that is now never added (as of [TACC/Core-CMS#506](https://github.com/TACC/Core-CMS/pull/506)).

## Related

- [FP-1665](https://jira.tacc.utexas.edu/browse/FP-1665)
- requires https://github.com/TACC/Core-CMS/pull/506

## Changes

- do not unset footer margin (64be2e2)

</details>

## Testing & Screenshots

See https://github.com/TACC/Core-CMS/pull/506.