### PR TITLE
V3.4.0/fp 1439 yearly site theme for texascale

### DIFF
--- a/texascale-org/templates/base.html
+++ b/texascale-org/templates/base.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load staticfiles get_url_match %}
+
+{% block assets_custom %}
+  {{ block.super }}
+
+  {% with year_slug=request.path|get_url_match:"/(2019|202\d)/" %}
+    {% if year_slug %}
+      {% with src="texascale-org/css/build/site."|add:year_slug|add:".css" %}
+  <link rel="stylesheet" href="{% static src %}" data-year_slug="{{year_slug}}">
+      {% endwith %}
+    {% else %}
+      {% if settings.DEBUG %}
+  <!-- will not load annual CSS cuz year_slug is {{year_slug}} not 2019…2029 -->
+      {% endif %}
+    {% endif %}
+  {% endwith %}
+{% endblock assets_custom %}

--- a/texascale-org/templates/fullwidth.html
+++ b/texascale-org/templates/fullwidth.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "./base.html" %}
 {% load cms_tags staticfiles %}
 
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}


### PR DESCRIPTION
## Overview

For Texascale, support annual `site.css` (e.g. `site.2022.css`).

## Related

- [FP-1439](https://jira.tacc.utexas.edu/browse/FP-1439)
- requires https://github.com/TACC/Core-CMS/pull/508
- mirrors https://github.com/TACC/Core-CMS-Resources/pull/140

## Changes

- extend `base.html` to load annual CSS
- update `fullwidth.html` to load texascale's `base.html`

## Testing & Screenshots & Notes

See https://github.com/TACC/Core-CMS/pull/508.