### PR TITLE
fix(ecep-cms): global accent colors full suite

### DIFF
--- a/ecep-cms/static/ecep-cms/css/src/site.css
+++ b/ecep-cms/static/ecep-cms/css/src/site.css
@@ -9,14 +9,19 @@
 
 /* https://github.com/TACC/Core-Styles/blob/main/source/_imports/settings/color.css */
 :root {
-  --global-color-accent--normal: #4F008F;
-  --global-color-accent--x-light: #A12EFF;
+  /* Accent */
   --global-color-accent--xxx-light: #DAADFF;
+  --global-color-accent--x-light: #A12EFF;
+  --global-color-accent--light: #6E00C8;
+  --global-color-accent--normal: #4F008F;
+  --global-color-accent--dark: #2F0054;
+  --global-color-accent--x-dark: #1E0037;
 
-  /* CAVEAT: Not accessible within paragraph text */
-  /* SEE: https://webaim.org/resources/linkcontrastchecker/?fcolor=000000&bcolor=FFFFFF&lcolor=4F008F */
+  --global-color-accent--alt: #DDC4F2;
+  --global-color-accent--weak: #5B00A440;
+
+  /* Link */
   --global-color-link-on-light--normal: var(--global-color-accent--normal);
-  /* WARNING: Color from Dev not Design */
   --global-color-link-on-dark--normal: var(--global-color-accent--xxx-light);
 }
 


### PR DESCRIPTION
## Overview

Provide full suite of global accent colors for `ecep-cms`.

## Related

- [FP-1499](https://jira.tacc.utexas.edu/browse/FP-1499) (tangentially… see testing)

## Changes

- added color vars
- added organizational core-cms comments
- removed detailed core-cms comments

## UI

![FP-1499 Development](https://user-images.githubusercontent.com/62723358/178406886-a1baaec3-e422-4262-a16d-795962947576.png)

## Testing

Tested during development of https://github.com/TACC/Core-CMS/pull/512.