### PR TITLE
chore(frontera, utrc): fp-1723 selectors for new markup

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -65,10 +65,10 @@
 .s-home__banner .o-section__banner-overlay {
   @extend %x-overlay--curtain;
 }
-.s-home__banner.o-section--style-dark .o-section__banner-overlay {
+.o-section--style-dark .s-home__banner .o-section__banner-overlay {
   --color-bkgd-rgb: var(--global-color-primary--x-dark-rgb);
 }
-.s-home__banner.o-section--style-light .o-section__banner-overlay {
+.o-section--style-light .s-home__banner .o-section__banner-overlay {
   --color-bkgd-rgb: var(--global-color-primary--x-light-rgb);
 }
 

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -12,10 +12,12 @@
 
 /* To avoid banner overlay being off-screen */
 @media (--medium-and-above) and (--x-wide-and-below) {
-  .o-section {
+  .s-home__banner,
+  .s-home__content {
     margin-inline: 116px;
   }
-  .o-section.container {
+  .s-home__banner.container,
+  .s-home__content.container {
     width: auto;
   }
 }

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -51,7 +51,7 @@
 /* Banner: Overlay */
 
 @media (--medium-and-above) {
-  .s-home__banner.o-section--banner .o-section__banner-overlay {
+  .o-section--banner .s-home__banner .o-section__banner-overlay {
     position: absolute;
     height: auto;
     width: 475px;
@@ -59,7 +59,7 @@
     bottom: 50px;
   }
 }
-.s-home__banner.o-section--banner .o-section__banner-overlay {
+.o-section--banner .s-home__banner .o-section__banner-overlay {
   @extend %x-overlay--callout;
 
   --color-text: inherit;
@@ -68,11 +68,11 @@
   color: var(--color-text);
   background-color: rgba(var(--color-bkgd-rgb), 0.9);
 }
-.s-home__banner.o-section--banner.o-section--style-dark .o-section__banner-overlay {
+.o-section--banner.o-section--style-dark .s-home__banner .o-section__banner-overlay {
   --color-text: var(--global-color-primary--xx-light);
   --color-bkgd-rgb: var(--global-color-primary--xx-dark-rgb);
 }
-.s-home__banner.o-section--banner.o-section--style-light .o-section__banner-overlay {
+.o-section--banner.o-section--style-light .s-home__banner .o-section__banner-overlay {
   --color-text: var(--global-color-primary--xx-dark);
   --color-bkgd-rgb: var(--global-color-primary--xx-light-rgb);
 }


### PR DESCRIPTION
## Overview / Changes

Adapt `.s-home__banner` selectors to new markup.

_I changed the markup slightly in dev and pprd.[^1]_

[^1]: For details, see https://github.com/TACC/Core-CMS/pull/513.

## Related

- [FP-1723](https://jira.tacc.utexas.edu/browse/FP-1723)
- required by https://github.com/TACC/Core-CMS/pull/513

## Testing / UI

See https://github.com/TACC/Core-CMS/pull/513.