### PR TITLE
fix(ecep): tup-151: hide "by: " line, stronger

### DIFF
--- a/ecep-cms/static/ecep-cms/css/src/site.css
+++ b/ecep-cms/static/ecep-cms/css/src/site.css
@@ -32,7 +32,8 @@
 /* COMPONENTS */
 
 /* https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/static/site_cms/css/src/_imports/components/django.cms.blog.app.item.css */
-.byline {
+.blog-list article .byline,
+article.post-detail .byline {
   display: none;
 }
 


### PR DESCRIPTION
## Overview

Hide byline for news on ECEP, for article **and** article list.

## Related

- required by https://github.com/TACC/Core-CMS/pull/519
- fixes https://github.com/TACC/Core-CMS-Resources/pull/154

## Changes

- explicit selectors
- specific selectors

## Testing / Screenshots

See https://github.com/TACC/Core-CMS/pull/519

## Notes

Previous attempt (https://github.com/TACC/Core-CMS-Resources/pull/154) was too simple.