### PR TITLE
fix(ecep-113): ecep blog css from site/ecep/main

### DIFF
--- a/ecep-cms/static/ecep-cms/css/src/app.blog.css
+++ b/ecep-cms/static/ecep-cms/css/src/app.blog.css
@@ -1,0 +1,20 @@
+/* https://github.com/TACC/Core-Styles/blob/main/source/_imports/components/django.cms.blog.css */
+@import url("_imports/components/django.cms.blog-selectors.css");
+
+
+
+/* To hide tags & categories */
+/* FAQ: Display none is not enough on grid instances */
+.app-blog.no-tags :--article .tags,
+.app-blog.no-categories :--article .categories {
+  display: none;
+}
+.app-blog.no-categories:not(.no-tags) :--article-item header {
+  --row-one-areas: 'tags tags';
+}
+.app-blog.no-tags:not(.no-categories) :--article-item header {
+  --row-one-areas: 'cats cats';
+}
+.app-blog.no-categories.no-tags :--article-item header {
+  --row-one-areas: 'none none';
+}

--- a/ecep-cms/templates/snippets/site-css.html
+++ b/ecep-cms/templates/snippets/site-css.html
@@ -1,4 +1,5 @@
 {% load staticfiles %}
 
-{# TODO: FP-1487: Move this to a templates/*.html that extends a site_cms one #}
+{# TODO: FP-1652: Move this to a templates/*.html that extends a site_cms one #}
 <link rel="stylesheet" href="{% static 'ecep-cms/css/build/site.css' %}">
+<link rel="stylesheet" href="{% static 'ecep-cms/css/build/app.blog.css' %}">


### PR DESCRIPTION
## Overview

CSS that is only in `site/ecep/main` but relied on by prod.

<details>The CSS should have been in a branch/PR (or at least a main commit), but I seem to have made the commits directly to `site/ecep/main`. Bad Wes.</details>

## Changes

- [fix(ecep): load blog custom selectors](https://github.com/TACC/Core-CMS-Resources/commit/2435456fa3720d5462a15312eb776f6b8f4c95fd)
- [feat(ecep): simplify project-specific css](https://github.com/TACC/Core-CMS-Resources/commit/63601f9c50f33ed0411744624e952c8046b677f1)
- [feat(ecep): project-specific blog css](https://github.com/TACC/Core-CMS-Resources/commit/ccf21cf591c3132adcb1d37692c13e4e1621b4dc)