### PR TITLE
feat(bm): FP-1798 link logo to home not ext site

### DIFF
--- a/brainmap-cms/settings_custom.py
+++ b/brainmap-cms/settings_custom.py
@@ -77,7 +77,7 @@ LOGO = [
     "brainmap",
     "brainmap-cms/img/org_logos/brainmap-logo.png",
     "",
-    "https://brainmap.org",
+    "/",
     "_self",
     "BrainMap Logo",
     "anonymous",


### PR DESCRIPTION
## Overview

BrainMap logo should link to home page, not an external site.

## Changes

- change URL in an array for brainmap logo setting

## Testing

1. Verify logo (yellow line globe) at https://pprd.brainmap.tacc.utexas.edu/guides/getting-started/ navigates to home page.

## UI

N/A

## Notes

Source: https://jira.tacc.utexas.edu/browse/BM-35?focusedId=25954&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-25954