### PR TITLE
feat(bm): BM-35 link logo to home not external site (for TACC/Core-CMS@v3.8.1)

### DIFF
--- a/brainmap-cms/settings_custom.py
+++ b/brainmap-cms/settings_custom.py
@@ -77,7 +77,7 @@ LOGO = [
     "brainmap",
     "brainmap-cms/img/org_logos/brainmap-logo.png",
     "",
-    "https://brainmap.org",
+    "/",
     "_self",
     "BrainMap Logo",
     "anonymous",


### PR DESCRIPTION
## Overview

BrainMap logo should link to home page, not an external site.

## Related

- [BM-35](https://jira.tacc.utexas.edu/browse/BM-35)
- mimics https://github.com/TACC/Core-CMS-Resources/pull/161

## Changes

- change URL in an array for brainmap logo setting

## Testing

1. Verify logo (yellow line globe) at https://pprd.brainmap.tacc.utexas.edu/guides/getting-started/ navigates to home page.

## UI

N/A

## Notes

Making a release off of [TACC/Core-CMS:v3.8.0](https://github.com/TACC/Core-CMS/releases/tag/v3.8.0)'s submodule pointer so I can deploy BrainMap without a CMS v3.9.0 release.