### PR TITLE
Task/fp 1801 guides breadcrumbs headings

### DIFF
--- a/apcd-cms/settings_custom.py
+++ b/apcd-cms/settings_custom.py
@@ -11,7 +11,7 @@ CMS_TEMPLATES = (
     ('standard.html', 'Standard'),
     ('fullwidth.html', 'Full Width'),
     ('guide.html', 'Guide'),
-    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/getting_started.tam.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')

--- a/ecep-cms/templates/snippets/page-members-css-old.html
+++ b/ecep-cms/templates/snippets/page-members-css-old.html
@@ -6,7 +6,7 @@
 hr { margin-bottom: 0; }
 h3 { margin-top: 0; }
 h3 > a[id] {
-  padding-top: var(--global-space--hr-margin, 1em);
+  padding-top: var(--global-space--hr-buffer-below, 1em);
   display: inline-block;
 }
 

--- a/example-cms/settings_custom.py
+++ b/example-cms/settings_custom.py
@@ -10,12 +10,13 @@
 #     ('standard.html', 'Standard'),
 #     ('fullwidth.html', 'Full Width'),
 
-#     # Support placeholder Portal homepage
+#     # Portal homepage placeholder
 #     ('home_portal.html', 'Standard Portal Homepage'),
 
-#     # Support temporary Portal guide pages
+#     # Portal guide pages
 #     ('guide.html', 'Guide'),
-#     ('guides/getting_started.html', 'Guide: Getting Started'),
+#     ('guides/getting_started.tam.html', 'Guide: Getting Started'),
+#     # ('guides/getting_started.v2.html', 'Guide: Getting Started'),
 #     ('guides/data_transfer.html', 'Guide: Data Transfer'),
 #     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
 #     ('guides/portal_technology.html', 'Guide: Portal Technology Stack'),

--- a/texascale-org/static/texascale-org/css/src/_imports/elements/html-elements.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/elements/html-elements.css
@@ -42,6 +42,8 @@ h4, h5, h6 {
 	font-family: benton-sans, sans-serif;
 	font-weight: 700;
 	font-style: normal;
+}
+h5, h6 {
 	text-transform: capitalize;
 }
 h4 {


### PR DESCRIPTION
## Overview

Updates from Core-CMS: new variable, new template.

## Related

- **[FP-1801]**
- [FP-1335]
- requires https://github.com/TACC/Core-CMS/pull/549
- APCD change mirrored by https://github.com/TACC/Core-CMS-Custom/pull/6

## Changes

- **feat(apcd): FP-1802 use tam getting started guide**
- **noop** chore(ecep): use new variable — _page redesign, old design unlikely to return_
- **noop** feat(example): add new template — _example cms project is only for reference_
- **noop** fix(texascale): FP-1335 do not force capitalize h4 — _texascale uses older CMS version_

## Testing & UI

### Setup

0. Log in to CMS http://apcd-qa.tacc.utexas.edu//admin.
1. (if not already present) Add a redirect from `/tam/register` to https://accounts-dev.tacc.utexas.edu/apcd/register .[^1]

[^1]: To avoid this requirement per Portal that uses TAM, we could instead add redirects in `urls.py` in CMS [or in Portal](https://github.com/TACC/Core-Portal/pull/688#discussion_r956488404).

### Steps

0. Log in to CMS https://apcd-qa.tacc.utexas.edu//admin.
1. Open https://apcd-qa.tacc.utexas.edu/help/getting-started/.
2. Confirm that the content beneath header matches this screenshot:
    ![Getting Started (TAM)](https://user-images.githubusercontent.com/62723358/187246298-66f8ba21-a52f-46bb-a91c-1b5b251740a7.png)
3. Verify it uses template "Getting Started" *not* "Standard".
4. Verify the Page template "Portal Technology Stack" is not available (from Page dropdown menu).

[FP-1801]: https://jira.tacc.utexas.edu/browse/FP-1801
[FP-1335]: https://jira.tacc.utexas.edu/browse/FP-1335