### PR TITLE
fix(settings): fp-1823 do not define email settings

### DIFF
--- a/apcd-cms/settings_custom.py
+++ b/apcd-cms/settings_custom.py
@@ -40,5 +40,7 @@ FAVICON = {
 # DJANGO (EMAIL)
 ########################
 
-EMAIL_HOST = "relay.tacc.utexas.edu"
+# Set on server, NOT here
+# https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/_settings/email.py
+# EMAIL_HOST = "..."
 DEFAULT_FROM_EMAIL = "no-reply@txapcd.org"

--- a/apcd-cms/settings_custom.py
+++ b/apcd-cms/settings_custom.py
@@ -41,6 +41,7 @@ FAVICON = {
 ########################
 
 # Set on server, NOT here
-# https://github.com/TACC/Core-CMS/blob/main/taccsite_cms/_settings/email.py
+# https://confluence.tacc.utexas.edu/x/coR9E
+# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 # EMAIL_HOST = "..."
 DEFAULT_FROM_EMAIL = "no-reply@txapcd.org"

--- a/apcd-cms/settings_custom.py
+++ b/apcd-cms/settings_custom.py
@@ -42,6 +42,6 @@ FAVICON = {
 
 # Set on server, NOT here
 # https://confluence.tacc.utexas.edu/x/coR9E
-# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+# EMAIL_BACKEND = "..."
 # EMAIL_HOST = "..."
-DEFAULT_FROM_EMAIL = "no-reply@txapcd.org"
+# DEFAULT_FROM_EMAIL = "..."


### PR DESCRIPTION
## Overview

Do not add default e-mail settings.

## Related

- [FP-1823](https://jira.tacc.utexas.edu/browse/FP-1823)
- requires https://github.com/TACC/Core-CMS/pull/550
- mirrored by https://github.com/TACC/Core-CMS-Custom/pull/7

## Changes

- remove hard-coded remote e-mail host
- add comment to direct developer to instructions

## Testing & UI

See https://github.com/TACC/Core-CMS/pull/550.