### PR TITLE
feat(css): use explicit sources for @import paths

### DIFF
--- a/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
+++ b/frontera-cms/static/frontera-cms/css/src/_imports/trumps/s-home.css
@@ -1,8 +1,8 @@
 /* TACC TRUMPS: Home (Page) */
-@import url("_imports/tools/x-truncate.css");
-@import url("_imports/tools/x-overlay.css");
-@import url("_imports/tools/x-center.css");
-@import url("_imports/tools/media-queries.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-overlay.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-center.css");
+@import url("_imports/tools/media-queries.css"); /* Core-CMS:/taccsite_cms/…/ */
 
 
 

--- a/frontera-cms/static/frontera-cms/css/src/template.home.css
+++ b/frontera-cms/static/frontera-cms/css/src/template.home.css
@@ -6,5 +6,5 @@
 /* TRUMPS */
 @import url("./_imports/trumps/s-home.css");
 
-@import url("_imports/trumps/s-article-list.css");
-@import url("_imports/trumps/s-article-preview.css");
+@import url("@tacc/core-styles/src/lib/_imports/trumps/s-article-list.css");
+@import url("@tacc/core-styles/src/lib/_imports/trumps/s-article-preview.css");

--- a/texascale-org/static/texascale-org/css/src/_imports/components/c-image-map.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/components/c-image-map.css
@@ -1,6 +1,6 @@
 /* TACC COMPONENTS: Image Map */
 
-@import url("_imports/components/c-image-map.css");
+@import url("@tacc/core-styles/src/lib/_imports/components/c-image-map.css");
 
 /* Styles are organized by OOCSS methodology */
 /* SEE: https://confluence.tacc.utexas.edu/x/VwALBg */

--- a/texascale-org/static/texascale-org/css/src/_imports/components/deprecated/c-offset-content.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/components/deprecated/c-offset-content.css
@@ -9,7 +9,7 @@ Content that should be offset from the flow of text within which it is placed.
 
 Styleguide Components.Texascale.Deprecated.OffsetContent
 */
-@import url("_imports/tools/media-queries.css");
+@import url("_imports/tools/media-queries.css"); /* Core-CMS:/taccsite_cms/…/ */
 
 [class*="c-offset-content--"] {
   --offset-distance: 8.5vw; /* NOTE: Value is from Texascale.org 2020 */

--- a/texascale-org/static/texascale-org/css/src/_imports/trumps/s-article-page.css
+++ b/texascale-org/static/texascale-org/css/src/_imports/trumps/s-article-page.css
@@ -12,7 +12,7 @@ Markup:
 
 Styleguide Trumps.Scopes.Article
 */
-@import url("_imports/tools/media-queries.css");
+@import url("_imports/tools/media-queries.css"); /* Core-CMS:/taccsite_cms/…/ */
 
 /* Prevent content after article from wrapping around floated content in article */
 .s-article-page .container,

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-home.css
@@ -1,7 +1,7 @@
 /* TACC TRUMPS: Home (Page) */
-@import url("_imports/tools/x-overlay.css");
-@import url("_imports/tools/media-queries.css");
-@import url("_imports/settings/border.css");
+@import url("@tacc/core-styles/src/lib/_imports/settings/border.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-overlay.css");
+@import url("_imports/tools/media-queries.css"); /* Core-CMS:/taccsite_cms/…/ */
 
 
 

--- a/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-icon-list.css
+++ b/utrc-cms/static/utrc-cms/css/src/_imports/trumps/s-icon-list.css
@@ -17,7 +17,7 @@ Markup:
 
 Styleguide Trumps.Scopes.IconList
 */
-@import url("_imports/tools/x-truncate.css");
+@import url("@tacc/core-styles/src/lib/_imports/tools/x-truncate.css");
 
 
 


### PR DESCRIPTION
## Overview / Changes

Load stylesheets using explicit paths where feasible.

<sup>This is a noop change to prove I have reviewed Core-CMS-Resources while performing https://github.com/TACC/Core-CMS/pull/605.</sup>

## Related

- expected by https://github.com/TACC/Core-CMS/pull/605

## Testing

See https://github.com/TACC/Core-CMS/pull/605.

## Notes

Should work on sites expecting Core-CMS 3.8.0 (Core-Styles 0.7.0-beta).

Any @imports from Core-CMS (not Core-Styles) can not be explicit. To those, I appended `/* Core-CMS:/taccsite_cms/…/ */`.