### PR TITLE
fix(brainmap): bm-41 logo should have text

### DIFF
--- a/brainmap-cms/settings_custom.py
+++ b/brainmap-cms/settings_custom.py
@@ -75,7 +75,7 @@ BRANDING = [ _SGCI_BRANDING, _TACC_BRANDING, _UTEXAS_BRANDING, _UTHSCSA_BRANDING
 
 LOGO = [
     "brainmap",
-    "brainmap-cms/img/org_logos/brainmap-logo--light-text-trans-bkgd--icon-only.png",
+    "brainmap-cms/img/org_logos/brainmap-logo--light-text-trans-bkgd--large-text.svg",
     "",
     "/",
     "_self",


### PR DESCRIPTION
## Overview

Add text to logo that should have it.

## Related

- fixes [BM-41](https://jira.tacc.utexas.edu/browse/BM-41)
- fixes text neglected in #170
- restores text from #167

## Changes

- **changed** logo file path

## Testing

1. Verify logo has text "BRAINMAP.ORG".

## UI

https://github.com/TACC/Core-CMS-Resources/assets/62723358/c26ed8a1-8cc4-4b95-82a8-e01d74bad183

