### PR TITLE
fix: v3.12.0-alpha.10 crash (add template redirects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Project-specific code built into the [Core CMS] project
 > **Warning**
 > This repository is deprecated. Do **not** deploy these websites via this repository with [TACC/Core-CMS#v3.12.0](https://github.com/TACC/Core-CMS/releases/tag/v3.12.0) or greater. **Instead**, [migrate them to Core CMS Custom](#port-project).[^1]
 
-[^1]: Deploying websites that are still in Core-CMS-Resources **and** have [old custom templates will trigger a major problem](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603194690). The prefered solution is [migration](#port-project). If you must deploy without migration, then [upgrade the website for Core-CMS v3.12](./docs/upgrade-project.md#for-CMS-v3-12).
+[^1]: Deploying websites that are still in Core-CMS-Resources **and** have [old custom templates will trigger a major problem](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603194690). The prefered solution is [migration](#port-project). If you must deploy without migration, then [upgrade the website for Core-CMS v3.12](./docs/upgrade-project.md#for-CMS-v312).
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Project-specific code built into the [Core CMS] project
 > **Warning**
 > This repository is deprecated. Do **not** deploy these websites via this repository with [TACC/Core-CMS#v3.12.0](https://github.com/TACC/Core-CMS/releases/tag/v3.12.0) or greater. **Instead**, [migrate them to Core CMS Custom](#port-project).[^1]
 
-[^1]: Deploying websites that are still in Core-CMS-Resources **and** have [old custom templates will trigger a major problem](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603194690). The prefered solution is [migration](#port-project). If you must deploy without migration, then [upgrade the website for Core-CMS v3.12](./docs/upgrade-project.md#for-CMS-v312).
+[^1]: Deploying websites that are still in Core-CMS-Resources **and** have [old custom templates will trigger a major problem](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603194690). The prefered solution is [migration](#port-project). If you must deploy without migration, then [upgrade the website for Core-CMS v3.12](./docs/upgrade-project.md#for-core-cms-v312).
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Project-specific code built into the [Core CMS] project
 > **Warning**
 > This repository is deprecated. Do **not** deploy these websites via this repository with [TACC/Core-CMS#v3.12.0](https://github.com/TACC/Core-CMS/releases/tag/v3.12.0) or greater. **Instead**, [migrate them to Core CMS Custom](#port-project).[^1]
 
-[^1]: [Websites with custom templates will experience a major problem.](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603194690) Even though not all websites have such templates **and** there is a [tested solution](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603215969), website development benefits so much from migration, that every opportunity is taken to encourage it.
+[^1]: Deploying websites that are still in Core-CMS-Resources **and** have [old custom templates will trigger a major problem](https://github.com/TACC/Core-CMS-Resources/pull/176#issuecomment-1603194690). The prefered solution is [migration](#port-project). If you must deploy without migration, then [upgrade the website for Core-CMS v3.12](./docs/upgrade-project.md#for-CMS-v3-12).
 
 ## Table of Contents
 

--- a/a2cps-cms/templates/fullwidth.html
+++ b/a2cps-cms/templates/fullwidth.html
@@ -1,0 +1,1 @@
+{% extends "a2cps_cms/templates/fullwidth.html" %}

--- a/a2cps-cms/templates/standard.html
+++ b/a2cps-cms/templates/standard.html
@@ -1,0 +1,1 @@
+{% extends "a2cps_cms/templates/standard.html" %}

--- a/a2cps_cms/settings_custom.py
+++ b/a2cps_cms/settings_custom.py
@@ -10,6 +10,8 @@
 CMS_TEMPLATES = (
     ('a2cps_cms/templates/standard.html', 'Standard'),
     ('a2cps_cms/templates/fullwidth.html', 'Full Width'),
+    ('a2cps-cms/templates/standard.html', 'DEPRECATED Standard'),
+    ('a2cps-cms/templates/fullwidth.html', 'DEPRECATED Full Width'),
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),

--- a/docs/upgrade-project.md
+++ b/docs/upgrade-project.md
@@ -1,0 +1,35 @@
+# Upgrade Project
+
+## for Core-CMS v3.12
+
+### Redirect Deprecated Templates
+
+**If** the custom project directory:
+
+- has `templates/standard.html` or
+- has `templates/fullwidth.html` or
+- has `templates/home.html`
+
+Then:
+
+1. Copy the templates to become deprecated templates:
+    - from `custom_project_dir/templates`
+    - to `custom-project-dir/templates`
+
+    > **Warning**
+    > The name `custom_project_dir` **must** match the old name as it was, including dashes.
+
+2. Edit the deprecated templates to extend the new templates e.g.
+
+    ```django
+    {% extends "custom_project_dir/templates/standard.html" %}
+    ```
+
+3. Update `settings_custom.py` to support deprecated templates:
+
+    ```diff
+        ('custom_project_dir/templates/standard.html', 'Standard'),
+        ('custom_project_dir/templates/fullwidth.html', 'Full Width'),
+    +   ('custom-project-dir/templates/standard.html', 'DEPRECATED Standard'),
+    +   ('custom-project-dir/templates/fullwidth.html', 'DEPRECATED Full Width'),
+    ```

--- a/frontera-cms/templates/fullwidth.html
+++ b/frontera-cms/templates/fullwidth.html
@@ -1,0 +1,1 @@
+{% extends "frontera_cms/templates/fullwidth.html" %}

--- a/frontera-cms/templates/home.html
+++ b/frontera-cms/templates/home.html
@@ -1,0 +1,1 @@
+{% extends "frontera_cms/templates/home.html" %}

--- a/frontera-cms/templates/standard.html
+++ b/frontera-cms/templates/standard.html
@@ -1,0 +1,1 @@
+{% extends "frontera_cms/templates/standard.html" %}

--- a/frontera_cms/settings_custom.py
+++ b/frontera_cms/settings_custom.py
@@ -13,6 +13,9 @@ CMS_TEMPLATES = (
     ('frontera_cms/templates/standard.html', 'Standard'),
     ('frontera_cms/templates/fullwidth.html', 'Full Width'),
     ('frontera_cms/templates/home.html', 'Homepage'),
+    ('frontera-cms/templates/standard.html', 'DEPRECATED Standard'),
+    ('frontera-cms/templates/fullwidth.html', 'DEPRECATED Full Width'),
+    ('frontera-cms/templates/home.html', 'DEPRECATED Homepage'),
 
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),


### PR DESCRIPTION
## Overview / Related

Fix server crash since https://github.com/TACC/Core-CMS/releases/tag/v3.12.0-alpha.10.

## Related

- required by https://github.com/TACC/Core-CMS/pull/676

## Changes

- **added** `frontera-cms` template redirects

## Testing

1. Build CMS image.
2. Deploy CMS image.
3. Access website.
4. Check whether site loads or crashes.

## UI

Just visit website ツ.

- [x] https://dev.fronteraweb.tacc.utexas.edu/
- [x] https://dev.a2cps.tacc.utexas.edu/

## Notes

The fixes alone seem **not** adequate for a CMS at v3.12 **and** on https://github.com/TACC/Core-CMS-Custom. Example: 
- https://github.com/TACC/Core-CMS-Custom/pull/175 — 2023-07-25