### PR TITLE
chore: delete apcd (migrated to Core-CMS-Custom)

### DIFF
--- a/apcd_cms/static/apcd_cms/css/src/placeholder.css
+++ b/apcd_cms/static/apcd_cms/css/src/placeholder.css
@@ -1,1 +1,0 @@
-/* FAQ: The CSS build process crashes without at least one project stylesheet */


### PR DESCRIPTION
## Overview

Delete APCD directory, because it was built at https://github.com/TACC/Core-CMS-Custom/tree/main/apcd-cms.

It's directory in Core-CMS is an unexplained leftover.

## Testing

- https://github.com/TACC/Core-CMS/pull/690