### PR TITLE
feat(protx): v3.12 support i.e. support deprecated templates

### DIFF
--- a/protx-cms/README.md
+++ b/protx-cms/README.md
@@ -1,0 +1,3 @@
+# Core-CMS-Resources - Deprecated Templates
+
+See [../docs/upgrade-project.md](../docs/upgrade-project.md).

--- a/protx-cms/templates/getting_started.html
+++ b/protx-cms/templates/getting_started.html
@@ -1,0 +1,1 @@
+{% extends "protx_cms/templates/getting_started.html" %}

--- a/protx_cms/settings_custom.py
+++ b/protx_cms/settings_custom.py
@@ -15,6 +15,7 @@ CMS_TEMPLATES = (
 
     ('guide.html', 'Guide'),
     ('protx_cms/templates/getting_started.html', 'Guide: Getting Started'),
+    ('protx-cms/templates/getting_started.html', 'DEPRECATED Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),
     ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
     ('guides/portal_technology.html', 'Guide: Portal Technology Stack')


### PR DESCRIPTION
## Overview

Allow deploy of ProTX on CMS v3.12. Support deprecated template.

## Changes

- **added** old template path redirect, setting, and doc

## Testing & UI

1. Verify website has same styles as prod.
2. Verify "Getting Started" template works.
3. Verify "Getting Started" template is clearly marked as "DEPRECATED".
    ![deprecated template](https://github.com/TACC/Core-CMS-Resources/assets/62723358/c78c28b3-0532-48b2-9b3f-a152a6ee3b96)