### PR TITLE
hotfix(example_cms): missing urls.py

### DIFF
--- a/example_cms/urls.py
+++ b/example_cms/urls.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from taccsite_cms.urls import *
+
+from django.urls import include, re_path
+
+urlpatterns += [
+    # Support `taggit_autosuggest` (from `djangocms-blog`)
+    re_path(r'^taggit_autosuggest/', include('taggit_autosuggest.urls')),
+]


### PR DESCRIPTION
## Overview

[Creating new post via `example_cms` causes error because of missing `urls.py` tweak.](https://github.com/nephila/djangocms-blog/issues/81#issuecomment-1819497693)

## Related

- coupled to https://github.com/TACC/Core-CMS/pull/750

## Changes

- **added** missing `urls.py` file/tweak

## Testing & UI

Skipped. Familiar mistake. Easy fix.