### PR TITLE
chore: tup-677 css/django/vite interoperability

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Set up a new local CMS instance.
     python manage.py createsuperuser
     # To use default "Username" and skip "Email address", press Enter at both prompts.
     # At "Password" prompts, you may use an easy-to-remember password.
-    python manage.py collectstatic --no-input --ignore assets/*/font*.css
+    python manage.py collectstatic --no-input
 
     ```
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Set up a new local CMS instance.
     python manage.py createsuperuser
     # To use default "Username" and skip "Email address", press Enter at both prompts.
     # At "Password" prompts, you may use an easy-to-remember password.
-    python manage.py collectstatic --no-input
+    python manage.py collectstatic --no-input --ignore assets/*/font*.css
 
     ```
 

--- a/frontera_cms/static/frontera_cms/css/src/_migrations/v1_v2/frontera.css
+++ b/frontera_cms/static/frontera_cms/css/src/_migrations/v1_v2/frontera.css
@@ -12,17 +12,17 @@ SRC: https://bitbucket.org/taccaci/frontera/src/master/client/css/frontera.scss
 /* FAQ: Though CMS default font is `Benton Sans`, old content uses these */
 @font-face {
     font-family: BentonSansBold;
-    src: url("/static/frontera_cms/fonts/archive/BentonSans-Bold.otf");
+    src: url("../../../../fonts/archive/BentonSans-Bold.otf");
 }
 
 @font-face {
     font-family: BentonSansMedium;
-    src: url("/static/frontera_cms/fonts/archive/BentonSans-Medium.otf");
+    src: url("../../../../fonts/archive/BentonSans-Medium.otf");
 }
 
 @font-face {
     font-family: BentonSansItalic;
-    src: url("/static/frontera_cms/fonts/archive/BentonSans-MediumItalic.otf");
+    src: url("../../../../fonts/archive/BentonSans-MediumItalic.otf");
 }
 
 /* … */
@@ -30,10 +30,10 @@ SRC: https://bitbucket.org/taccaci/frontera/src/master/client/css/frontera.scss
 /* HELP: Wesley assumes that old content uses these… but where? */
 @font-face {
 	font-family: 'icon-worksregular';
-	src: url('/static/frontera_cms/fonts/archive/icon-works-webfont.eot');
-	src: url('/static/frontera_cms/fonts/archive/icon-works-webfont.eot?#iefix') format('embedded-opentype'),
-		url('/static/frontera_cms/fonts/archive/icon-works-webfont.woff') format('woff'),
-		url('/static/frontera_cms/fonts/archive/icon-works-webfont.svg#icon-worksregular') format('svg');
+	src: url('../../../../fonts/archive/icon-works-webfont.eot');
+	src: url('../../../../fonts/archive/icon-works-webfont.eot?#iefix') format('embedded-opentype'),
+		url('../../../../fonts/archive/icon-works-webfont.woff') format('woff'),
+		url('../../../../fonts/archive/icon-works-webfont.svg#icon-worksregular') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }

--- a/utrc-cms/templates/home.html
+++ b/utrc-cms/templates/home.html
@@ -1,0 +1,1 @@
+{% extends "utrc_cms/templates/home.html" %}

--- a/utrc_cms/settings_custom.py
+++ b/utrc_cms/settings_custom.py
@@ -12,6 +12,7 @@ CMS_TEMPLATES = (
     ('fullwidth.html', 'Full Width'),
 
     ('utrc_cms/templates/home.html', 'Home'),
+    ('utrc-cms/templates/home.html', 'DEPRECATED Home'),
 
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),

--- a/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
+++ b/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
@@ -1,6 +1,4 @@
 /* TACC TRUMPS: Home (Page) */
-/* FAQ: All Core-Styles settings are available via Core-CMS v3.9 site.css */
-/* @import url("@tacc/core-styles/src/lib/_imports/settings/border.css"); */
 /* FAQ: These Core-Styles are unchanged from v0.12 (Core-CMS v3.9) to v2.7 */
 @import url("@tacc/core-styles/src/lib/_imports/tools/x-overlay.css");
 /* NOTE: We had loaded media-queries.css from Core-CMS:/taccsite_cms,


### PR DESCRIPTION
## Overview

Edit CSS so that Django and Vite do not use it unexpectedly.

## Related

- [TUP-677](https://tacc-main.atlassian.net/browse/TUP-677)

<details><summary>Pull Requests</summary>

- https://github.com/TACC/tup-ui/pull/400 requires:
    - https://github.com/TACC/Core-Styles/pull/285
    - https://github.com/TACC/Core-CMS/pull/780 requires:
        - https://github.com/TACC/Core-Styles/pull/285
        - https://github.com/TACC/Core-CMS-Resources/pull/197

</details>

## Changes

### CSS
- **refactored** comments that suggest to `@import` code
- **refactored** absolute `/static` paths to be relative

### Static Files / Cache
- **documented** additional parameter for `collectstatic` command

## Testing

0. **Uncertain.** See https://github.com/TACC/tup-ui/pull/398.
1. Verify the custom fonts Frontera uses (on it's old-style pages) still load e.g.:
    - `/static/frontera_cms/fonts/archive/BentonSans-Bold.otf`
    - `/static/frontera_cms/fonts/archive/icon-works-webfont.…`
1. Verify UTRC builds and deploys without error.

## UI

| Website | |
| - | - |
| Frontera (Dev) | <img width="960" alt="dev frontera with tup-677" src="https://github.com/TACC/Core-CMS-Resources/assets/62723358/61c6babf-6d4c-4d96-bc82-90746d8298b0">
| Frontera (Prod) | <img width="960" alt="prod frontera sans tup-677" src="https://github.com/TACC/Core-CMS-Resources/assets/62723358/c52b7af8-a0e9-4839-97a7-a3281ceb0255">
| UTRC (Pre-Prod) | <img width="960" alt="pprd utrc cms v4" src="https://github.com/TACC/Core-CMS-Resources/assets/62723358/f500114e-253b-4930-b67d-57abc7185318">