### PR TITLE
enhance: CMD-182 design tokens

### DIFF
--- a/brainmap_cms/static/brainmap_cms/css/src/site.css
+++ b/brainmap_cms/static/brainmap_cms/css/src/site.css
@@ -15,10 +15,9 @@
   --global-color-accent--dark: hsl(229 45% 35%);
   --global-color-accent--x-dark: hsl(229 45% 30%);
 
+  /* DEPRECATED */
   --global-color-accent--alt: hsl(229 22% 77%);
   --global-color-accent--weak: hsl(229, 45%, 52%, 0.25);
-
-  /* Link */
   --global-color-link-on-light--normal: var(--global-color-accent--normal);
   --global-color-link-on-dark--normal: var(--global-color-accent--x-light);
 }

--- a/frontera_cms/static/frontera_cms/css/src/_imports/settings/color.css
+++ b/frontera_cms/static/frontera_cms/css/src/_imports/settings/color.css
@@ -8,6 +8,7 @@
   --global-color-accent--dark: #64563E;    /* originally #6039cc */
   --global-color-accent--x-dark: #403014;  /* originally #3d189b */
 
+  /* DEPRECATED */
   --global-color-accent--alt: #E0D8C9;     /* originally #d2cce7 */
   --global-color-accent--weak: #9D702140;  /* originally #6039cc40 */
 }

--- a/frontera_cms/static/frontera_cms/css/src/_imports/trumps/s-home.css
+++ b/frontera_cms/static/frontera_cms/css/src/_imports/trumps/s-home.css
@@ -70,10 +70,10 @@
   @extend %x-overlay--curtain;
 }
 .o-section--style-dark .s-home__banner .o-section__banner-overlay {
-  --color-bkgd: var(--global-color-primary--x-dark);
+  background-color: rgba( from design-token('color.gray.dark-x'), 0.65 );
 }
 .o-section--style-light .s-home__banner .o-section__banner-overlay {
-  --color-bkgd: var(--global-color-primary--x-light);
+  background-color: rgba( from design-token('color.gray.light-x'), 0.65 );
 }
 
 

--- a/frontera_cms/static/frontera_cms/css/src/_imports/trumps/s-home.css
+++ b/frontera_cms/static/frontera_cms/css/src/_imports/trumps/s-home.css
@@ -70,10 +70,10 @@
   @extend %x-overlay--curtain;
 }
 .o-section--style-dark .s-home__banner .o-section__banner-overlay {
-  background-color: rgba( from design-token('color.gray.dark-x'), 0.65 );
+  background-color: rgb( from design-token('color.gray.dark-x') r g b / 0.65 );
 }
 .o-section--style-light .s-home__banner .o-section__banner-overlay {
-  background-color: rgba( from design-token('color.gray.light-x'), 0.65 );
+  background-color: rgb( from design-token('color.gray.light-x') r g b / 0.65 );
 }
 
 

--- a/frontera_cms/static/frontera_cms/css/src/_imports/trumps/s-home.css
+++ b/frontera_cms/static/frontera_cms/css/src/_imports/trumps/s-home.css
@@ -70,10 +70,10 @@
   @extend %x-overlay--curtain;
 }
 .o-section--style-dark .s-home__banner .o-section__banner-overlay {
-  --color-bkgd-rgb: var(--global-color-primary--x-dark-rgb);
+  --color-bkgd: var(--global-color-primary--x-dark);
 }
 .o-section--style-light .s-home__banner .o-section__banner-overlay {
-  --color-bkgd-rgb: var(--global-color-primary--x-light-rgb);
+  --color-bkgd: var(--global-color-primary--x-light);
 }
 
 

--- a/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
+++ b/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
@@ -67,16 +67,15 @@
 .o-section--banner .s-home__banner .o-section__banner-overlay {
   @extend %x-overlay--callout;
 
-  --color-text: inherit;
-  --color-bkgd: var(--global-color-primary--normal);
+  background-color: rgba( from design-token('color.gray.medium'), 0.9 );
 }
 .o-section--banner.o-section--style-dark .s-home__banner .o-section__banner-overlay {
-  --color-text: var(--global-color-primary--xx-light);
-  --color-bkgd: var(--global-color-primary--xx-dark);
+  color: var(--global-color-primary--xx-light);
+  background-color: rgba( from design-token('color.gray.dark-2x'), 0.9 );
 }
 .o-section--banner.o-section--style-light .s-home__banner .o-section__banner-overlay {
-  --color-text: var(--global-color-primary--xx-dark);
-  --color-bkgd: var(--global-color-primary--xx-light);
+  color: var(--global-color-primary--xx-dark);
+  background-color: rgba( from design-token('color.gray.light-2x'), 0.9 );
 }
 
 

--- a/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
+++ b/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
@@ -69,9 +69,6 @@
 
   --color-text: inherit;
   --color-bkgd: var(--global-color-primary--normal);
-
-  color: var(--color-text);
-  background-color: rgba( from var(--color-bkgd) r g b / 0.9);
 }
 .o-section--banner.o-section--style-dark .s-home__banner .o-section__banner-overlay {
   --color-text: var(--global-color-primary--xx-light);

--- a/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
+++ b/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
@@ -67,15 +67,15 @@
 .o-section--banner .s-home__banner .o-section__banner-overlay {
   @extend %x-overlay--callout;
 
-  background-color: rgba( from design-token('color.gray.medium'), 0.9 );
+  background-color: rgb( from design-token('color.gray.medium') r g b / 0.9 );
 }
 .o-section--banner.o-section--style-dark .s-home__banner .o-section__banner-overlay {
   color: var(--global-color-primary--xx-light);
-  background-color: rgba( from design-token('color.gray.dark-2x'), 0.9 );
+  background-color: rgb( from design-token('color.gray.dark-2x') r g b / 0.9 );
 }
 .o-section--banner.o-section--style-light .s-home__banner .o-section__banner-overlay {
   color: var(--global-color-primary--xx-dark);
-  background-color: rgba( from design-token('color.gray.light-2x'), 0.9 );
+  background-color: rgb( from design-token('color.gray.light-2x') r g b / 0.9 );
 }
 
 

--- a/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
+++ b/utrc_cms/static/utrc_cms/css/src/_imports/trumps/s-home.css
@@ -68,18 +68,18 @@
   @extend %x-overlay--callout;
 
   --color-text: inherit;
-  --color-bkgd-rgb: var(--global-color-primary--normal);
+  --color-bkgd: var(--global-color-primary--normal);
 
   color: var(--color-text);
-  background-color: rgba(var(--color-bkgd-rgb), 0.9);
+  background-color: rgba( from var(--color-bkgd) r g b / 0.9);
 }
 .o-section--banner.o-section--style-dark .s-home__banner .o-section__banner-overlay {
   --color-text: var(--global-color-primary--xx-light);
-  --color-bkgd-rgb: var(--global-color-primary--xx-dark-rgb);
+  --color-bkgd: var(--global-color-primary--xx-dark);
 }
 .o-section--banner.o-section--style-light .s-home__banner .o-section__banner-overlay {
   --color-text: var(--global-color-primary--xx-dark);
-  --color-bkgd-rgb: var(--global-color-primary--xx-light-rgb);
+  --color-bkgd: var(--global-color-primary--xx-light);
 }
 
 


### PR DESCRIPTION
## Overview

Do **not** use `-rgb` CSS variables. Update `%x-overlay` usage. Deprecate `alt`/`weak` colors.

## Related

- requires https://github.com/TACC/Core-Styles/pull/372
- required by https://github.com/TACC/Core-CMS/pull/863

## Changes

- **documented** deprecated colors
- **changed** `%x-overlay` to override latest properties
- **changed** `%x-overlay` usages to use design tokens

## Testing

Verify homepage `%x-overlay` usage's color and opacity are unchanged on:
- [x] Frontera
- [x] UTRC

## UI

Skipped.