### PR TITLE
fix: do not show breadcrumbs since Core-CMS#870

### DIFF
--- a/_3dem_cms/templates/fullwidth.html
+++ b/_3dem_cms/templates/fullwidth.html
@@ -7,6 +7,8 @@
   {{ block.super }}
 {% endblock assets_font %}
 
+{# To remove container and breadcrumbs #}
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
 {% placeholder "content" %}
 {% endblock content %}

--- a/texascale_cms/templates/fullwidth.html
+++ b/texascale_cms/templates/fullwidth.html
@@ -13,6 +13,8 @@
   <link rel="stylesheet" href="{% static 'texascale_cms/css/build/site.css' %}">
 {% endblock assets_custom %}
 
+{# To remove container and breadcrumbs #}
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
 {% placeholder "content" %}
 {% endblock content %}


### PR DESCRIPTION
### Overview / Related

Explicitly do **not** show breadcrumbs since https://github.com/TACC/Core-CMS/pull/870.

### Changes

- **added** code to hide breadcrumbs

### Notes

<details><summary>Reasoning</summary>

In Core-CMS, breadcrumbs become their own block. Until now, `fullwidth.html` templates of a custom CMS have implicitly had no breadcrumbs. To continue to **not** show breadcrumbs, these templates must:
- **either** explicitly hide breadcrumbs
- **or** extend Core-CMS `fullwidth.html`

I am more comfortable performing the former without testing. The latter is more appropriate but requires testing (which requires many steps and documenting) and would be moot if I can migrate the CMS's to Core-CMS-Custom ([WP-197](https://tacc-main.atlassian.net/browse/WP-197)) without a custom template (as I have done for some migrated CMS's).

</details>