### PR TITLE
fix: do not show container since Core-CMS#870

### DIFF
--- a/_3dem_cms/templates/fullwidth.html
+++ b/_3dem_cms/templates/fullwidth.html
@@ -8,9 +8,11 @@
 {% endblock assets_font %}
 
 {# To remove container and breadcrumbs #}
-{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
-{% placeholder "content" %}
+  {% block cms_content %}
+    {% placeholder "content" %}
+  {% endblock cms_content %}
+  {% block app_content %}{% endblock app_content %}
 {% endblock content %}
 
 {% block assets_custom %}

--- a/_3dem_cms/templates/fullwidth.html
+++ b/_3dem_cms/templates/fullwidth.html
@@ -7,6 +7,8 @@
   {{ block.super }}
 {% endblock assets_font %}
 
+{# To remove container and breadcrumbs #}
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
 {% placeholder "content" %}
 {% endblock content %}

--- a/texascale_cms/templates/fullwidth.html
+++ b/texascale_cms/templates/fullwidth.html
@@ -13,6 +13,8 @@
   <link rel="stylesheet" href="{% static 'texascale_cms/css/build/site.css' %}">
 {% endblock assets_custom %}
 
+{# To remove container and breadcrumbs #}
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
 {% placeholder "content" %}
 {% endblock content %}

--- a/texascale_cms/templates/fullwidth.html
+++ b/texascale_cms/templates/fullwidth.html
@@ -14,7 +14,9 @@
 {% endblock assets_custom %}
 
 {# To remove container and breadcrumbs #}
-{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
-{% placeholder "content" %}
+  {% block cms_content %}
+    {% placeholder "content" %}
+  {% endblock cms_content %}
+  {% block app_content %}{% endblock app_content %}
 {% endblock content %}


### PR DESCRIPTION
### Overview / Related

Explicitly do **not** show breadcrumbs since https://github.com/TACC/Core-CMS/pull/870.

### Changes

- **updated** code to hide container (and breadcrumbs)

### Related

- continues #201