### PR TITLE
refactor: no need to redefine title block

### DIFF
--- a/_3dem_cms/templates/fullwidth.html
+++ b/_3dem_cms/templates/fullwidth.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load cms_tags static %}
 
-{% block title %}{% page_attribute "page_title" %}{% endblock title %}
-
 {% block assets_font %}
   {{ block.super }}
 {% endblock assets_font %}

--- a/texascale_cms/templates/fullwidth.html
+++ b/texascale_cms/templates/fullwidth.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load cms_tags static %}
 
-{% block title %}{% page_attribute "page_title" %}{% endblock title %}
-
 {% block assets_font %}
   <link rel="stylesheet" href="https://use.typekit.net/xnr7bof.css">
 {% endblock assets_font %}


### PR DESCRIPTION
### Overview

Remove `{% block title %}`, because CMS will set it properly in `base.html`.

### Changes

- **removed** now-redundant block

### Testing & UI

Skipped.