### PR TITLE
chore: delete deprecated templates

### DIFF
--- a/texascale-org/templates/article.freeform.html
+++ b/texascale-org/templates/article.freeform.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.freeform.html" %}

--- a/texascale-org/templates/article.html
+++ b/texascale-org/templates/article.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.html" %}

--- a/texascale-org/templates/article.image-map.html
+++ b/texascale-org/templates/article.image-map.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.image-map.html" %}

--- a/texascale-org/templates/article.sidebar-right.html
+++ b/texascale-org/templates/article.sidebar-right.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.sidebar-right.html" %}

--- a/texascale-org/templates/article.visual.html
+++ b/texascale-org/templates/article.visual.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/article.visual.html" %}

--- a/texascale-org/templates/category.html
+++ b/texascale-org/templates/category.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/category.html" %}

--- a/texascale-org/templates/fullwidth.html
+++ b/texascale-org/templates/fullwidth.html
@@ -1,1 +1,0 @@
-{% extends "texascale_cms/templates/fullwidth.html" %}


### PR DESCRIPTION
## Overview

Delete deprecated templates unused since https://github.com/TACC/Texascale-CMS/pull/5.

## Related

- https://github.com/TACC/Texascale-CMS/pull/5